### PR TITLE
課題の完了・復元・完了リスト整理フローを改善

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Assignment Manager for YNU LMS",
-  "short_name": "ExtOfLMS",
-  "description": "Manage your homework easily",
+  "name": "YNU LMS 課題管理",
+  "short_name": "課題管理",
+  "description": "YNU LMS の課題を一覧で確認できます",
   "version": "2.4.1",
   "author": "Vimmer",
   "icons": {

--- a/src/fetch_homework_storage.js
+++ b/src/fetch_homework_storage.js
@@ -2,113 +2,157 @@
 // Fetch homework to submit or resubmit
 
 const A_TYPE = {
-    other: 1,
-    report: 2,
-    test: 3,
-    questionnaire: 4,
+  other: 1,
+  report: 2,
+  test: 3,
+  questionnaire: 4,
 };
+
+function getDueTime(assignment) {
+  if (!assignment || !assignment['due']) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const dueTime = new Date(assignment['due']).getTime();
+  return Number.isFinite(dueTime) ? dueTime : Number.POSITIVE_INFINITY;
+}
+
+function isExpiredAssignment(assignment) {
+  return getDueTime(assignment) <= Date.now();
+}
+
+async function removeExpiredAssignmentsFromStorage() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(null, (data) => {
+      if (chrome.runtime.lastError) {
+        console.error(
+          'Assignment Manager: failed to load expired assignments',
+          chrome.runtime.lastError
+        );
+        resolve();
+        return;
+      }
+
+      const expiredAssignmentIds = Object.values(data)
+        .filter(
+          (assignment) =>
+            assignment &&
+            assignment['id'] &&
+            assignment['id'] !== 'PREFERENCES' &&
+            isExpiredAssignment(assignment)
+        )
+        .map((assignment) => assignment['id']);
+
+      if (expiredAssignmentIds.length === 0) {
+        resolve();
+        return;
+      }
+
+      chrome.storage.sync.remove(expiredAssignmentIds, () => {
+        if (chrome.runtime.lastError) {
+          console.error(
+            'Assignment Manager: failed to remove expired assignments',
+            chrome.runtime.lastError
+          );
+        }
+        resolve();
+      });
+    });
+  });
+}
 
 /* main */
 (async () => {
-    setTextLanguage()
+  setTextLanguage();
 
-    const newAssignments = await getAssignments()
-    saveToStorage(newAssignments)
-    
-    const assignments = await loadFromStorage()
-    const curLecId = getLectureID()
-    injectAssignmentTable(assignments.filter(x => x.subject_id == curLecId))
+  await removeExpiredAssignmentsFromStorage();
+  const newAssignments = await getAssignments();
+  try {
+    await saveToStorage(newAssignments);
+  } catch (error) {
+    console.error('Assignment Manager: failed to save assignments', error);
+  }
 
+  const assignments = await loadFromStorage();
+  const curLecId = getLectureID();
+  injectAssignmentTable(assignments.filter((x) => x.subject_id == curLecId));
 })();
 
-
 function setTextLanguage() {
-    //LANGUAGE = document.querySelector("#langList > option[selected]").textContent
-    LANGUAGE = getLanguage()
-    if(LANGUAGE == 'English') {
-        ASSIGNMENT_FOR_THIS_LECTURE_TXT = 'Assignments'
-        ASSIGNMENT_TXT = 'Assignment'
-        DEADLINE_TXT = 'DEADLINE'
-        NOT_EXECUTED_TXT = 'Not executed'
-        NOT_VIEWED_TXT = 'Not viewed'
-        NOT_SUBMITTED_TXT = 'Not submitted'
-        NOT_RESPONDED_TXT = 'Not responded'
-        RESUBMISSION_TXT = 'Resubmission'
-    } else {
-        ASSIGNMENT_FOR_THIS_LECTURE_TXT = '課題'
-        ASSIGNMENT_TXT = '課題名'
-        DEADLINE_TXT = '提出期限'
-        NOT_VIEWED_TXT = '未参照'
-        NOT_SUBMITTED_TXT = '未提出'
-        NOT_EXECUTED_TXT = '未実施'
-        NOT_RESPONDED_TXT = '未回答'
-        RESUBMISSION_TXT = '再提出'
-    }
+  //LANGUAGE = document.querySelector("#langList > option[selected]").textContent
+  LANGUAGE = getLanguage();
+  if (LANGUAGE == 'English') {
+    ASSIGNMENT_FOR_THIS_LECTURE_TXT = 'Assignments';
+    ASSIGNMENT_TXT = 'Assignment';
+    DEADLINE_TXT = 'DEADLINE';
+    NOT_EXECUTED_TXT = 'Not executed';
+    NOT_VIEWED_TXT = 'Not viewed';
+    NOT_SUBMITTED_TXT = 'Not submitted';
+    NOT_RESPONDED_TXT = 'Not responded';
+    RESUBMISSION_TXT = 'Resubmission';
+  } else {
+    ASSIGNMENT_FOR_THIS_LECTURE_TXT = '課題';
+    ASSIGNMENT_TXT = '課題名';
+    DEADLINE_TXT = '提出期限';
+    NOT_VIEWED_TXT = '未参照';
+    NOT_SUBMITTED_TXT = '未提出';
+    NOT_EXECUTED_TXT = '未実施';
+    NOT_RESPONDED_TXT = '未回答';
+    RESUBMISSION_TXT = '再提出';
+  }
 }
 
 function getLanguage() {
-    const LOGOUT_TEXT = document.querySelector("#form-id > div > ul > li.logoutButtonFrame > a").textContent
-    return LOGOUT_TEXT.includes("Logout") ? "English" : "日本語"
-}
-
-
-class Assignment {
-    constructor(id, subject_ja, subject_en, name, due, isVisible) {
-        this.id = id
-        this.subject_ja = subject_ja
-        this.subject_en = subject_en
-        this.name = name
-        this.due = due.toJSON()
-        this.isVisible = isVisible
-    }
+  const LOGOUT_TEXT = document.querySelector(
+    '#form-id > div > ul > li.logoutButtonFrame > a'
+  ).textContent;
+  return LOGOUT_TEXT.includes('Logout') ? 'English' : '日本語';
 }
 
 async function getAssignments() {
-    class Assignment {
-        constructor(id, subject_id, subject_ja, subject_en, name, due, isVisible) {
-            this.id = id
-            this.subject_id = subject_id
-            this.subject_ja = subject_ja
-            this.subject_en = subject_en
-            this.name = name
-            this.due = due.toJSON()
-            this.isVisible = isVisible
-        }
+  class Assignment {
+    constructor(id, subject_id, subject_ja, subject_en, name, due, isVisible) {
+      this.id = id;
+      this.subject_id = subject_id;
+      this.subject_ja = subject_ja;
+      this.subject_en = subject_en;
+      this.name = name;
+      this.due = due.toJSON();
+      this.isVisible = isVisible;
     }
-    
-    if (LANGUAGE == "English") {
-        //regex = /(Submission Due on|Resubmission deadline|Response Due on|Activity Due on):(.*)/
-        //availableText = 'Available'
-        unavailableText = 'Unavailable'
-    }
-    else if (LANGUAGE == "日本語") {
-        //regex = /(提出期限|再提出期限|回答期限|実施期限):(.*)/
-        //availableText = '公開中'
-        unavailableText = '公開終了'
-    }
+  }
 
+  if (LANGUAGE == 'English') {
+    //regex = /(Submission Due on|Resubmission deadline|Response Due on|Activity Due on):(.*)/
+    //availableText = 'Available'
+    unavailableText = 'Unavailable';
+  } else if (LANGUAGE == '日本語') {
+    //regex = /(提出期限|再提出期限|回答期限|実施期限):(.*)/
+    //availableText = '公開中'
+    unavailableText = '公開終了';
+  }
 
-    const subject_id = getLectureID()
-    let subject_texts = getSubjectTexts(LANGUAGE)
-    //const subject_ja = subject_texts[2]
-    //const subject_en = subject_texts[4]
-    if (subject_texts instanceof Array) {
-        subject_ja = subject_texts[1]
-        subject_en = subject_texts[3]
-    } else  {
-        subject_ja = subject_texts
-        subject_en = subject_texts
-    }
+  const subject_id = getLectureID();
+  let subject_texts = getSubjectTexts(LANGUAGE);
+  //const subject_ja = subject_texts[2]
+  //const subject_en = subject_texts[4]
+  if (subject_texts instanceof Array) {
+    subject_ja = subject_texts[1];
+    subject_en = subject_texts[3];
+  } else {
+    subject_ja = subject_texts;
+    subject_en = subject_texts;
+  }
 
+  let assignments = [];
+  const idsInStorage = await loadIDsFromStorage();
 
-    let assignments = []
-    const idsInStorage = await loadIDsFromStorage()
+  //const assignmentDateElems = document.querySelectorAll("tbody > tr > td.td03")
+  const assignmentDateElems = Array.from(
+    document.querySelectorAll('[id^=REP],[id^=ANK],[id^=TES]')
+  ).map((x) => x.parentElement);
 
-    //const assignmentDateElems = document.querySelectorAll("tbody > tr > td.td03")
-    const assignmentDateElems = Array.from(document.querySelectorAll('[id^=REP],[id^=ANK],[id^=TES]')).map(x => x.parentElement)
-
-    for (const dateElem of assignmentDateElems) {
-        /*
+  for (const dateElem of assignmentDateElems) {
+    /*
         let isDue = dateElem.textContent.match(regex);
         let isAvailable = dateElem.parentElement.querySelector("td.td02").textContent.trim() == availableText
 
@@ -126,186 +170,262 @@ async function getAssignments() {
             }
         }
         */
-        let isNotSubmitted = dateElem.querySelector('td.jyugyeditCell > span').textContent == NOT_SUBMITTED_TXT  | dateElem.querySelector('td.jyugyeditCell > span').textContent == NOT_VIEWED_TXT | dateElem.querySelector('td.jyugyeditCell > span').textContent == NOT_EXECUTED_TXT | dateElem.querySelector('td.jyugyeditCell > span').textContent == NOT_RESPONDED_TXT | dateElem.querySelector('td.jyugyeditCell > span').textContent == RESUBMISSION_TXT
-        let isDue = !dateElem.textContent.includes(unavailableText);
-        
-        if (isDue && isNotSubmitted) {
-            const id = dateElem.querySelector('td.kyozaititleCell').id
-            const name = dateElem.querySelector('td.kyozaititleCell').textContent.trim().match(/(.*)\n(\s*)(.*)/)[3]
-            const dueDate = new Date(dateElem.querySelectorAll('td.jyugyeditCell')[0].textContent.trim())
-            dueDate.setSeconds(dueDate.getSeconds() - 1)
+    let isNotSubmitted =
+      dateElem.querySelector('td.jyugyeditCell > span').textContent ==
+        NOT_SUBMITTED_TXT ||
+      dateElem.querySelector('td.jyugyeditCell > span').textContent ==
+        NOT_VIEWED_TXT ||
+      dateElem.querySelector('td.jyugyeditCell > span').textContent ==
+        NOT_EXECUTED_TXT ||
+      dateElem.querySelector('td.jyugyeditCell > span').textContent ==
+        NOT_RESPONDED_TXT ||
+      dateElem.querySelector('td.jyugyeditCell > span').textContent ==
+        RESUBMISSION_TXT;
+    let isDue = !dateElem.textContent.includes(unavailableText);
 
-            if (!idsInStorage.includes(id)) {
-                const assignment = new Assignment(id, subject_id, subject_ja, subject_en, name, dueDate, true)
-                assignments.push(assignment)
-            } else {
-                console.log(id + ' is already added')
-            }
-        }
+    if (isDue && isNotSubmitted) {
+      const id = dateElem.querySelector('td.kyozaititleCell').id;
+      const name = dateElem
+        .querySelector('td.kyozaititleCell')
+        .textContent.trim()
+        .match(/(.*)\n(\s*)(.*)/)[3];
+      const dueDate = new Date(
+        dateElem.querySelectorAll('td.jyugyeditCell')[0].textContent.trim()
+      );
+      dueDate.setSeconds(dueDate.getSeconds() - 1);
+      if (dueDate.getTime() <= Date.now()) {
+        continue;
+      }
+
+      if (!idsInStorage.includes(id)) {
+        const assignment = new Assignment(
+          id,
+          subject_id,
+          subject_ja,
+          subject_en,
+          name,
+          dueDate,
+          true
+        );
+        assignments.push(assignment);
+      }
     }
+  }
 
-    return assignments
+  return assignments;
 }
 
-
 function getSubjectTexts(lang) {
-    //return document.querySelector("#cs_loginInfo_left ul li:not(#home)").textContent.match(/(\>\s)(.*)(\[)(.*)(\])(\[.*\])/)
-    if (lang == 'English')
-        return document.querySelector("body > div.base > div.headerContents > div.courseMenu > div.courseName").textContent.trim()
-    else {
-        let elem = document.querySelector("body > div.base > div.headerContents > div.courseMenu > div.courseName").textContent.trim().match(/(.*)(\[)(.*)(\])/)
-        if (elem != null && elem.length > 4) {
-            return elem
-        }
-        return document.querySelector("body > div.base > div.headerContents > div.courseMenu > div.courseName").textContent.trim()
+  //return document.querySelector("#cs_loginInfo_left ul li:not(#home)").textContent.match(/(\>\s)(.*)(\[)(.*)(\])(\[.*\])/)
+  if (lang == 'English')
+    return document
+      .querySelector(
+        'body > div.base > div.headerContents > div.courseMenu > div.courseName'
+      )
+      .textContent.trim();
+  else {
+    let elem = document
+      .querySelector(
+        'body > div.base > div.headerContents > div.courseMenu > div.courseName'
+      )
+      .textContent.trim()
+      .match(/(.*)(\[)(.*)(\])/);
+    if (elem != null && elem.length > 4) {
+      return elem;
     }
-
-
-
+    return document
+      .querySelector(
+        'body > div.base > div.headerContents > div.courseMenu > div.courseName'
+      )
+      .textContent.trim();
+  }
 }
 
 function injectAssignmentTable(assignments) {
-    const BANNER_ICON_URL = '/lms/img/cs/yazi3.gif'
-    
+  const BANNER_ICON_URL = '/lms/img/cs/yazi3.gif';
 
-    let bannerElem = document.createElement('div')
-    bannerElem.id = 'title'
-    bannerElem.innerHTML = `
+  let bannerElem = document.createElement('div');
+  bannerElem.id = 'title';
+  bannerElem.innerHTML = `
         <h2>${ASSIGNMENT_FOR_THIS_LECTURE_TXT}
             <img src=\"${BANNER_ICON_URL}\">
         </h2>
-    `
+    `;
 
-    let listBlockElem = document.createElement('div')
-    listBlockElem.id = 'list_block'
+  let listBlockElem = document.createElement('div');
+  listBlockElem.id = 'list_block';
 
-    let tableElem = document.createElement('table')
-    tableElem.className = 'cs_table2'
+  let tableElem = document.createElement('table');
+  tableElem.className = 'cs_table2';
 
-    let tbody = document.createElement('tbody')
-    let columns = document.createElement('tr')
-    columns.innerHTML = `
+  let tbody = document.createElement('tbody');
+  let columns = document.createElement('tr');
+  columns.innerHTML = `
         <th width="37%">${ASSIGNMENT_TXT}</th>
         <th width="10%">${DEADLINE_TXT}</th>
-    `
+    `;
 
-    tbody.appendChild(columns)
+  tbody.appendChild(columns);
 
-    assignments.sort((a, b) => new Date(a['due']) - new Date(b['due']))
-    for (const assignment of assignments) {
-        // name, due
-        let record = document.createElement('tr')
-        
-        // name
-        let nameColumn = document.createElement('td')
+  assignments.sort((a, b) => getDueSortTime(a) - getDueSortTime(b));
+  for (const assignment of assignments) {
+    // name, due
+    let record = document.createElement('tr');
 
-        let img = document.createElement('img')
-        img.src = getIconURLFromID(assignment['id'])
-        let a = document.createElement('a')
-        a.href = 'javascript:void(0)'
-        a.setAttribute('onclick', `kyozaiTitleLink('${assignment['id']}','0${checkAssignmentType(assignment['id'])}')`)
-        a.innerText = assignment.name
-        
-        nameColumn.appendChild(img)
-        nameColumn.appendChild(a)
+    // name
+    let nameColumn = document.createElement('td');
 
-        // due
-        let dueColumn = document.createElement('td')
-        dueColumn.align = 'center'
-        if (assignment.due) {
-            dueColumn.innerText = new Date(assignment.due).toLocaleString('ja-JP')
-        } else {
-            dueColumn.innerText = '-'
-        }
-        
+    let img = document.createElement('img');
+    img.src = getIconURLFromID(assignment['id']);
+    let a = document.createElement('a');
+    a.href = 'javascript:void(0)';
+    a.setAttribute('onclick', createKyozaiTitleOnclick(assignment['id']));
+    a.innerText = assignment.name;
 
-        record.appendChild(nameColumn)
-        record.appendChild(dueColumn)
+    nameColumn.appendChild(img);
+    nameColumn.appendChild(a);
 
-        tbody.append(record)
+    // due
+    let dueColumn = document.createElement('td');
+    dueColumn.align = 'center';
+    const dueDate = getDueDate(assignment);
+    if (dueDate) {
+      dueColumn.innerText = dueDate.toLocaleString('ja-JP');
+    } else {
+      dueColumn.innerText = '期限なし';
     }
 
-    tableElem.appendChild(tbody)
-    listBlockElem.appendChild(tableElem)
-    listBlockElem.style = 'box-sizing: border-box; height: 100%; max-height: 15rem; margin-bottom: 2rem; overflow-y: auto'
-    
-    
-    //let mainElem = document.querySelector('div#main')
-    let mainElem = document.querySelector('div.contentsColumn')
-    mainElem.prepend(listBlockElem)
-    mainElem.prepend(bannerElem)
+    record.appendChild(nameColumn);
+    record.appendChild(dueColumn);
+
+    tbody.append(record);
+  }
+
+  tableElem.appendChild(tbody);
+  listBlockElem.appendChild(tableElem);
+  listBlockElem.style =
+    'box-sizing: border-box; height: 100%; max-height: 15rem; margin-bottom: 2rem; overflow-y: auto';
+
+  //let mainElem = document.querySelector('div#main')
+  let mainElem = document.querySelector('div.contentsColumn');
+  mainElem.prepend(listBlockElem);
+  mainElem.prepend(bannerElem);
 }
 
+function createKyozaiTitleOnclick(assignmentId) {
+  const assignmentType = `0${checkAssignmentType(assignmentId)}`;
+  return `kyozaiTitleLink(${JSON.stringify(assignmentId)},${JSON.stringify(
+    assignmentType
+  )})`;
+}
 
+function getDueDate(assignment) {
+  if (!assignment || !assignment['due']) {
+    return null;
+  }
+  const dueDate = new Date(assignment['due']);
+  return Number.isNaN(dueDate.getTime()) ? null : dueDate;
+}
+
+function getDueSortTime(assignment) {
+  const dueDate = getDueDate(assignment);
+  return dueDate ? dueDate.getTime() : Number.POSITIVE_INFINITY;
+}
 
 function getIconURLFromID(hw_name) {
-    const type = checkAssignmentType(hw_name)
-    if (type == A_TYPE.report) {
-        //return "/lms/img/cs/icon2b.gif"
-        return "/lms/img/pc/material_report_S.png"
-    }
-    else if (type == A_TYPE.questionnaire) {
-        //return "/lms/img/cs/icon7b.gif"
-        return "/lms/img/pc/material_questionnaire_S.png"
-    }
-    else if (type == A_TYPE.test) {
-        //return "/lms/img/cs/icon3b.gif"
-        return "/lms/img/pc/material_exam_S.png"
-    }
-    else {
-        //return "/lms/img/cs/icon5b.gif"
-        return "/lms/img/pc/material_study-materials_S.png"
-    }
+  const type = checkAssignmentType(hw_name);
+  if (type == A_TYPE.report) {
+    //return "/lms/img/cs/icon2b.gif"
+    return '/lms/img/pc/material_report_S.png';
+  } else if (type == A_TYPE.questionnaire) {
+    //return "/lms/img/cs/icon7b.gif"
+    return '/lms/img/pc/material_questionnaire_S.png';
+  } else if (type == A_TYPE.test) {
+    //return "/lms/img/cs/icon3b.gif"
+    return '/lms/img/pc/material_exam_S.png';
+  } else {
+    //return "/lms/img/cs/icon5b.gif"
+    return '/lms/img/pc/material_study-materials_S.png';
+  }
 }
 
 function checkAssignmentType(id) {
-    if (id.includes("REP")) {
-        //return "/lms/img/cs/icon2b.gif"
-        return A_TYPE.report
-    }
-    else if (id.includes("ANK")) {
-        //return "/lms/img/cs/icon7b.gif"
-        return A_TYPE.questionnaire
-    }
-    else if (id.includes("TES")) {
-        //return "/lms/img/cs/icon3b.gif"
-        return A_TYPE.test
-    }
-    else {
-        //return "/lms/img/cs/icon5b.gif"
-        return A_TYPE.other
-    }
-
+  if (id.includes('REP')) {
+    //return "/lms/img/cs/icon2b.gif"
+    return A_TYPE.report;
+  } else if (id.includes('ANK')) {
+    //return "/lms/img/cs/icon7b.gif"
+    return A_TYPE.questionnaire;
+  } else if (id.includes('TES')) {
+    //return "/lms/img/cs/icon3b.gif"
+    return A_TYPE.test;
+  } else {
+    //return "/lms/img/cs/icon5b.gif"
+    return A_TYPE.other;
+  }
 }
 
 function getLectureID() {
-    //return document.querySelector("#cs_loginInfo_left ul li:not(#home)").textContent.match(/(.*)\[(.*)\]/)[2]
-    let subjectNameElem = document.querySelector("body > div.base > div.headerContents > div.breadCrumbBar > ul > li.current > a > p").textContent.match(/(.*)\[(.*)\]/)
-    if (subjectNameElem != null && subjectNameElem.length > 2) 
-        return document.querySelector("body > div.base > div.headerContents > div.breadCrumbBar > ul > li.current > a > p").textContent.match(/(.*)\[(.*)\]/)[2]
-    else
-        return 'AAA1234' 
+  //return document.querySelector("#cs_loginInfo_left ul li:not(#home)").textContent.match(/(.*)\[(.*)\]/)[2]
+  let subjectNameElem = document
+    .querySelector(
+      'body > div.base > div.headerContents > div.breadCrumbBar > ul > li.current > a > p'
+    )
+    .textContent.match(/(.*)\[(.*)\]/);
+  if (subjectNameElem != null && subjectNameElem.length > 2)
+    return document
+      .querySelector(
+        'body > div.base > div.headerContents > div.breadCrumbBar > ul > li.current > a > p'
+      )
+      .textContent.match(/(.*)\[(.*)\]/)[2];
+  else return 'AAA1234';
 }
 
-function saveToStorage(assignments) {
-    for (const assignment of assignments) {
-        let record = {}
-        record[assignment.id] = assignment
-        chrome.storage.sync.set(record)
-    }
+async function saveToStorage(assignments) {
+  if (assignments.length === 0) {
+    return;
+  }
+
+  const records = {};
+  for (const assignment of assignments) {
+    records[assignment.id] = assignment;
+  }
+
+  return new Promise((resolve, reject) => {
+    chrome.storage.sync.set(records, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve();
+    });
+  });
 }
 
 async function loadFromStorage() {
-    return new Promise(resolve => {chrome.storage.sync.get(null, (data) => {
-        resolve(Object.values(data))
-    })})
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(null, (data) => {
+      resolve(
+        Object.values(data).filter(
+          (a) =>
+            a &&
+            a['id'] &&
+            a['id'] !== 'PREFERENCES' &&
+            a['isDeleted'] !== true &&
+            a['isVisible'] !== false
+        )
+      );
+    });
+  });
 }
 
 async function loadIDsFromStorage() {
-    return new Promise(resolve => {
-        chrome.storage.sync.get(null, (data) => {
-            let assignmentIDs = Object.values(data).map(a => a['id'])
-            resolve(assignmentIDs)
-        })
-    })
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(null, (data) => {
+      let assignmentIDs = Object.values(data)
+        .filter((a) => a && a['id'] && a['id'] !== 'PREFERENCES')
+        .map((a) => a['id']);
+      resolve(assignmentIDs);
+    });
+  });
 }

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,215 +1,812 @@
-let LANGUAGE = getLanguage();
-if (LANGUAGE == 'English') {
-  var CLEAR_TXT = 'Clear all assignments';
-  var CLEAR_OVERDUE_TXT = 'Clear all overdue assignments';
-  var SUBJECT_TXT = 'Lecture';
-  var ASSIGNMENT_FOR_THIS_LECTURE_TXT = 'Assignments';
-  var ASSIGNMENT_TXT = 'Assignment';
-  var DEADLINE_TXT = 'DEADLINE';
-  var SHOW_TXT = '表示';
-  var RECORD_IN_PAGE_TXT = ' assignemts per page';
-  var ERROR_1_TO_100 = 'Values must be between 1 and 100';
-} else {
-  var CLEAR_TXT = '課題全消去';
-  var CLEAR_OVERDUE_TXT = '提出期限を過ぎた課題を全消去';
-  var SUBJECT_TXT = '講義';
-  var ASSIGNMENT_FOR_THIS_LECTURE_TXT = '課題';
-  var ASSIGNMENT_TXT = '課題名';
-  var DEADLINE_TXT = '提出期限';
-  var SHOW_TXT = '表示';
-  var RECORD_IN_PAGE_TXT = '1ページに表示する課題数: ';
-  var ERROR_1_TO_100 = '1 - 100 までの数値を入力してください';
-}
+var SHOW_ALL_TXT = 'すべて再表示';
+var HIDDEN_ASSIGNMENTS_TXT = '完了した課題';
+var SHOW_HIDDEN_ASSIGNMENTS_TXT = '完了した課題を表示';
+var HIDE_HIDDEN_ASSIGNMENTS_TXT = '完了した課題を閉じる';
+var DELETE_COMPLETED_TXT = '完了リストを空にする';
+var STOPPED_FETCH_ASSIGNMENTS_TXT = '取得を止めている記録';
+var SHOW_STOPPED_FETCH_ASSIGNMENTS_TXT = '取得を止めている記録を表示';
+var HIDE_STOPPED_FETCH_ASSIGNMENTS_TXT = '取得を止めている記録を閉じる';
+var ALLOW_REFETCH_DELETED_ASSIGNMENTS_TXT =
+  '選択した課題を再取得できるようにする';
+var PERMANENTLY_DELETE_STOPPED_FETCH_TXT = '選択した記録を完全に削除';
+var SUBJECT_TXT = '講義';
+var ASSIGNMENT_TXT = '課題名';
+var DEADLINE_TXT = '提出期限';
+var SHOW_TXT = '一覧に出す';
+var RECORD_IN_PAGE_TXT = '表示件数: ';
+var NO_DEADLINE_TXT = '期限なし';
+var EMPTY_TXT = '表示できる課題はありません。';
+var STATUS_TXT =
+  'チェックあり: 一覧に表示 / チェックなし: 完了リストへ移動。完了した課題もチェックを入れると一覧に戻せます。提出期限を過ぎると自動で削除されます。';
+var ERROR_1_TO_100 = '1 - 100 までの数値を入力してください';
+
+const DEFAULT_PREFERENCES = {
+  id: 'PREFERENCES',
+  recordPerPage: 6,
+};
 
 (async () => {
-  loadSetting();
-  injectAssignmentTable();
+  loadSetting(renderPopup);
 })();
 
-function getLanguage() {
-  const language = navigator.language;
-  return language == 'ja-JP' ? '日本語' : 'English';
+function getDisplaySubject(assignment) {
+  return assignment['subject_ja'] || assignment['subject_en'] || '';
 }
 
-function loadSetting() {
-  chrome.storage.local.get('PREFERENCES', (data) => {
-    const prefs = data['PREFERENCES'];
-    if (!prefs) {
-      chrome.storage.local.set({
-        PREFERENCES: { id: 'PREFERENCES', recordPerPage: 6 },
-      });
-    }
-  });
-}
-async function loadFromStorage() {
-  let assignments = [];
-  chrome.storage.sync.get(null, (data) => {
-    for (const assignment of Object.values(data)) {
-      assignments.push(assignment);
-    }
-  });
+function getDisplayAssignmentName(assignment) {
+  return assignment['name'] || assignment['id'] || '';
 }
 
-function injectAssignmentTable(assignments) {
-  const DISPLAY_LIMIT_DAYS = 21;
-
-  let bannerElem = document.createElement('div');
-  let clearBtn = document.createElement('button');
-  clearBtn.innerText = CLEAR_TXT;
-  clearBtn.addEventListener('click', () => {
-    chrome.storage.sync.clear();
-    location.reload();
-  });
-  clearBtn.style.marginRight = '10px';
-  bannerElem.appendChild(clearBtn);
-
-  let clearOverdueBtn = document.createElement('button');
-  clearOverdueBtn.innerText = CLEAR_OVERDUE_TXT;
-  clearOverdueBtn.addEventListener('click', () => {
-    chrome.storage.sync.get(null, (data) => {
-      const assignments = Object.values(data);
-      for (const assignment of assignments) {
-        if (new Date(assignment.due).getTime() < new Date().getTime()) {
-          chrome.storage.sync.remove(assignment.id);
-          location.reload();
-        }
-      }
-    });
-  });
-  clearOverdueBtn.style.marginRight = '10px';
-  bannerElem.appendChild(clearOverdueBtn);
-
-  let recordPerPageLabel = document.createElement('label');
-  recordPerPageLabel.innerText = RECORD_IN_PAGE_TXT;
-  let recordPerPageInput = document.createElement('input');
-  chrome.storage.local.get('PREFERENCES', (data) => {
-    const prefs = data['PREFERENCES'];
-    if (prefs) {
-      recordPerPageInput.value = prefs.recordPerPage;
-    } else {
-      recordPerPageInput.value = 6;
-    }
-  });
-  recordPerPageInput.type = 'number';
-  recordPerPageInput.min = 1;
-  recordPerPageInput.max = 100;
-
-  recordPerPageInput.addEventListener('input', () => {
-    const value = parseInt(recordPerPageInput.value);
-    console.log(value);
-    if (1 <= value && value <= 100) {
-      chrome.storage.local.set({
-        PREFERENCES: {
-          id: 'PREFERENCES',
-          recordPerPage: recordPerPageInput.value,
-        },
-      });
-    } else if (value) {
-      alert(ERROR_1_TO_100);
-    }
-  });
-  if (LANGUAGE === 'English') {
-    bannerElem.appendChild(recordPerPageInput);
-    bannerElem.appendChild(recordPerPageLabel);
-  } else {
-    bannerElem.appendChild(recordPerPageLabel);
-    bannerElem.appendChild(recordPerPageInput);
+function getDueSortTime(assignment) {
+  if (!assignment || !assignment['due']) {
+    return Number.POSITIVE_INFINITY;
   }
 
-  let listBlockElem = document.createElement('div');
-  listBlockElem.id = 'list_block';
+  const dueTime = new Date(assignment['due']).getTime();
+  return Number.isFinite(dueTime) ? dueTime : Number.POSITIVE_INFINITY;
+}
 
-  let tableElem = document.createElement('table');
+function compareAssignmentsByDue(a, b) {
+  const visibilityCompare =
+    Number(isVisibleAssignment(b)) - Number(isVisibleAssignment(a));
+  if (visibilityCompare !== 0) {
+    return visibilityCompare;
+  }
+  return getDueSortTime(a) - getDueSortTime(b);
+}
+
+function hasValidDue(assignment) {
+  return Number.isFinite(getDueSortTime(assignment));
+}
+
+function isOverdue(assignment) {
+  return hasValidDue(assignment) && getDueSortTime(assignment) <= Date.now();
+}
+
+function isDeletedAssignment(assignment) {
+  return assignment && assignment['isDeleted'] === true;
+}
+
+function isVisibleAssignment(assignment) {
+  return assignment && assignment['isVisible'] !== false;
+}
+
+function createDeletedAssignmentTombstone(assignment) {
+  return {
+    id: assignment['id'],
+    subject_id: assignment['subject_id'],
+    subject_ja: assignment['subject_ja'],
+    subject_en: assignment['subject_en'],
+    name: assignment['name'],
+    due: assignment['due'],
+    isVisible: false,
+    isDeleted: true,
+    deletedAt: new Date().toJSON(),
+    deletedReason: 'completedCleanup',
+  };
+}
+
+function loadSetting(callback) {
+  chrome.storage.local.get('PREFERENCES', (data) => {
+    const prefs = data['PREFERENCES'];
+    chrome.storage.local.set(
+      {
+        PREFERENCES: {
+          ...DEFAULT_PREFERENCES,
+          ...(prefs || {}),
+          id: 'PREFERENCES',
+        },
+      },
+      callback
+    );
+  });
+}
+
+function savePreferences(updates) {
+  chrome.storage.local.get('PREFERENCES', (data) => {
+    chrome.storage.local.set({
+      PREFERENCES: {
+        ...DEFAULT_PREFERENCES,
+        ...(data['PREFERENCES'] || {}),
+        ...updates,
+        id: 'PREFERENCES',
+      },
+    });
+  });
+}
+
+function refreshPopup() {
+  document.body.innerHTML = '';
+  renderPopup();
+}
+
+function showStatus(message, color = '#2285b1') {
+  const statusElem = document.querySelector('#assignment-manager-popup-status');
+  if (statusElem) {
+    statusElem.style.color = color;
+    statusElem.innerText = message;
+  }
+}
+
+function stylePopupButton(buttonElem, variant = 'default') {
+  buttonElem.style.minHeight = '30px';
+  buttonElem.style.padding = '4px 10px';
+  buttonElem.style.border = '1px solid #b8c7d0';
+  buttonElem.style.borderRadius = '4px';
+  buttonElem.style.backgroundColor = '#fff';
+  buttonElem.style.color = '#226c86';
+  buttonElem.style.cursor = 'pointer';
+  buttonElem.style.fontWeight = '700';
+  if (variant === 'danger') {
+    buttonElem.style.backgroundColor = '#fff7f7';
+    buttonElem.style.borderColor = '#d8a5a5';
+    buttonElem.style.color = '#9f2b2b';
+  }
+}
+
+function setAssignmentVisibility(assignment, isVisible, callback) {
+  chrome.storage.sync.get(assignment['id'], (data) => {
+    if (chrome.runtime.lastError) {
+      callback({ error: true });
+      return;
+    }
+
+    const currentAssignment = data[assignment['id']];
+    if (!currentAssignment) {
+      callback({ skippedMissing: true });
+      return;
+    }
+
+    if (isDeletedAssignment(currentAssignment)) {
+      callback({ skippedDeleted: true });
+      return;
+    }
+
+    const updatedAssignment = {
+      ...currentAssignment,
+      isVisible,
+    };
+    if (isVisible) {
+      delete updatedAssignment['hiddenAt'];
+      delete updatedAssignment['hiddenReason'];
+      delete updatedAssignment['isDeleted'];
+      delete updatedAssignment['deletedAt'];
+      delete updatedAssignment['deletedReason'];
+    } else {
+      updatedAssignment['hiddenAt'] = new Date().toJSON();
+      updatedAssignment['hiddenReason'] =
+        updatedAssignment['hiddenReason'] || 'manual';
+    }
+
+    const keypair = {};
+    keypair[updatedAssignment['id']] = updatedAssignment;
+    chrome.storage.sync.set(keypair, () => {
+      callback({ error: Boolean(chrome.runtime.lastError) });
+    });
+  });
+}
+
+function removeExpiredAssignmentsFromStorage(callback = () => {}) {
+  chrome.storage.sync.get(null, (data) => {
+    if (chrome.runtime.lastError) {
+      showStatus(
+        '期限切れ課題を確認できませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      callback();
+      return;
+    }
+
+    const expiredAssignmentIds = [];
+    for (const assignment of Object.values(data)) {
+      if (
+        assignment &&
+        assignment['id'] &&
+        assignment['id'] !== 'PREFERENCES' &&
+        isOverdue(assignment)
+      ) {
+        expiredAssignmentIds.push(assignment['id']);
+      }
+    }
+
+    if (expiredAssignmentIds.length === 0) {
+      callback();
+      return;
+    }
+
+    chrome.storage.sync.remove(expiredAssignmentIds, () => {
+      if (chrome.runtime.lastError) {
+        showStatus(
+          '期限切れ課題を自動削除できませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+      }
+      callback();
+    });
+  });
+}
+
+function showAllAssignments() {
+  chrome.storage.sync.get(null, (data) => {
+    const updates = {};
+    for (const assignment of Object.values(data)) {
+      if (
+        assignment &&
+        assignment['id'] !== 'PREFERENCES' &&
+        !isDeletedAssignment(assignment)
+      ) {
+        const updatedAssignment = {
+          ...assignment,
+          isVisible: true,
+        };
+        delete updatedAssignment['hiddenAt'];
+        delete updatedAssignment['hiddenReason'];
+        updates[assignment['id']] = updatedAssignment;
+      }
+    }
+    chrome.storage.sync.set(updates, () => {
+      if (chrome.runtime.lastError) {
+        showStatus(
+          '再表示できませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+      refreshPopup();
+    });
+  });
+}
+
+function deleteCompletedAssignments() {
+  chrome.storage.sync.get(null, (data) => {
+    const hiddenAssignments = Object.values(data).filter(
+      (assignment) =>
+        assignment &&
+        assignment['id'] !== 'PREFERENCES' &&
+        assignment['isVisible'] === false &&
+        !isDeletedAssignment(assignment)
+    );
+    const hiddenAssignmentIds = hiddenAssignments.map(
+      (assignment) => assignment['id']
+    );
+
+    if (hiddenAssignmentIds.length === 0) {
+      showStatus('完了リストはすでに空です。');
+      return;
+    }
+
+    const shouldDelete = window.confirm(
+      `完了リスト内の${hiddenAssignmentIds.length}件をこの画面から消します。消した課題はこの画面では戻せませんが、同じ課題が自動で再追加されないように記録だけ残します。必要な課題は先に一覧へ戻してください。`
+    );
+    if (!shouldDelete) {
+      return;
+    }
+
+    const updates = {};
+    for (const assignment of hiddenAssignments) {
+      updates[assignment['id']] = createDeletedAssignmentTombstone(assignment);
+    }
+
+    chrome.storage.sync.set(updates, () => {
+      if (chrome.runtime.lastError) {
+        showStatus(
+          '完了リストを空にできませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+      showStatus(`${hiddenAssignmentIds.length}件を完了リストから消しました。`);
+      setTimeout(refreshPopup, 1200);
+    });
+  });
+}
+
+function formatSelectedCount(count) {
+  return count === 0 ? '0件選択中' : `${count}件選択済み`;
+}
+
+function updateSelectedRefetchControls(selectedAssignments, controls) {
+  const selectedCount = selectedAssignments.size;
+  controls.countElem.innerText = formatSelectedCount(selectedCount);
+  controls.allowRefetchBtn.disabled = selectedCount === 0;
+  controls.allowRefetchBtn.style.cursor =
+    selectedCount === 0 ? 'not-allowed' : 'pointer';
+  controls.allowRefetchBtn.style.opacity = selectedCount === 0 ? '0.55' : '1';
+  if (controls.permanentDeleteBtn) {
+    controls.permanentDeleteBtn.disabled = selectedCount === 0;
+    controls.permanentDeleteBtn.style.cursor =
+      selectedCount === 0 ? 'not-allowed' : 'pointer';
+    controls.permanentDeleteBtn.style.opacity =
+      selectedCount === 0 ? '0.55' : '1';
+  }
+}
+
+function allowDeletedAssignmentsRefetch(assignments) {
+  const assignmentIds = assignments
+    .filter((assignment) => assignment && assignment['id'])
+    .map((assignment) => assignment['id']);
+  if (assignmentIds.length === 0) {
+    showStatus('再取得できるようにする課題が選択されていません。');
+    return;
+  }
+
+  chrome.storage.sync.get(assignmentIds, (data) => {
+    if (chrome.runtime.lastError) {
+      showStatus(
+        '課題を再取得できる状態に戻せませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      return;
+    }
+
+    const deletedAssignmentIds = Object.values(data)
+      .filter(isDeletedAssignment)
+      .map((assignment) => assignment['id']);
+    if (deletedAssignmentIds.length === 0) {
+      showStatus('再取得できるようにする課題が選択されていません。');
+      return;
+    }
+
+    const shouldAllowRefetch = window.confirm(
+      `選択した${deletedAssignmentIds.length}件を、講義ページを開いたときに再取得できる状態に戻します。LMS上で未提出・未回答として残っている課題だけが取得されます。`
+    );
+    if (!shouldAllowRefetch) {
+      return;
+    }
+
+    chrome.storage.sync.remove(deletedAssignmentIds, () => {
+      if (chrome.runtime.lastError) {
+        showStatus(
+          '課題を再取得できる状態に戻せませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+
+      showStatus(
+        `${deletedAssignmentIds.length}件を再取得できる状態に戻しました。該当する講義ページを開くと取得されます。`
+      );
+      setTimeout(refreshPopup, 1200);
+    });
+  });
+}
+
+function permanentlyDeleteDeletedAssignments(assignments) {
+  const assignmentIds = assignments
+    .filter((assignment) => assignment && assignment['id'])
+    .map((assignment) => assignment['id']);
+  if (assignmentIds.length === 0) {
+    showStatus('完全に削除する記録が選択されていません。');
+    return;
+  }
+
+  chrome.storage.sync.get(assignmentIds, (data) => {
+    if (chrome.runtime.lastError) {
+      showStatus(
+        '取得を止めている記録を完全に削除できませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      return;
+    }
+
+    const deletedAssignmentIds = Object.values(data)
+      .filter(isDeletedAssignment)
+      .map((assignment) => assignment['id']);
+    if (deletedAssignmentIds.length === 0) {
+      showStatus('完全に削除する記録が選択されていません。');
+      return;
+    }
+
+    const shouldDeletePermanently = window.confirm(
+      `選択した${deletedAssignmentIds.length}件の取得を止めている記録を完全に削除します。LMS上に同じ未提出・未回答課題が残っている場合、講義ページを開くと再取得されることがあります。`
+    );
+    if (!shouldDeletePermanently) {
+      return;
+    }
+
+    chrome.storage.sync.remove(deletedAssignmentIds, () => {
+      if (chrome.runtime.lastError) {
+        showStatus(
+          '取得を止めている記録を完全に削除できませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+
+      showStatus(
+        `${deletedAssignmentIds.length}件の取得を止めている記録を完全に削除しました。`
+      );
+      setTimeout(refreshPopup, 1200);
+    });
+  });
+}
+
+function createStoppedFetchSection(deletedAssignments) {
+  const wrapperElem = document.createElement('div');
+  wrapperElem.style.display = 'none';
+  wrapperElem.style.margin = '8px 0 10px';
+  wrapperElem.style.padding = '8px';
+  wrapperElem.style.border = '1px solid #ddd';
+  wrapperElem.style.borderRadius = '4px';
+  wrapperElem.style.backgroundColor = '#fafafa';
+
+  const toolsElem = document.createElement('div');
+  toolsElem.style.display = 'flex';
+  toolsElem.style.alignItems = 'center';
+  toolsElem.style.flexWrap = 'wrap';
+  toolsElem.style.gap = '8px';
+  toolsElem.style.marginBottom = '8px';
+
+  const selectedDeletedAssignments = new Map();
+  const countElem = document.createElement('strong');
+  countElem.style.color = '#1f4f5e';
+  countElem.style.backgroundColor = '#eaf3f6';
+  countElem.style.border = '1px solid #cfe0e6';
+  countElem.style.borderRadius = '4px';
+  countElem.style.padding = '5px 8px';
+  toolsElem.appendChild(countElem);
+
+  const allowRefetchBtn = document.createElement('button');
+  allowRefetchBtn.innerText = ALLOW_REFETCH_DELETED_ASSIGNMENTS_TXT;
+  stylePopupButton(allowRefetchBtn);
+  allowRefetchBtn.addEventListener('click', () => {
+    allowDeletedAssignmentsRefetch(
+      Array.from(selectedDeletedAssignments.values())
+    );
+  });
+  toolsElem.appendChild(allowRefetchBtn);
+
+  const permanentDeleteBtn = document.createElement('button');
+  permanentDeleteBtn.innerText = PERMANENTLY_DELETE_STOPPED_FETCH_TXT;
+  stylePopupButton(permanentDeleteBtn, 'danger');
+  permanentDeleteBtn.addEventListener('click', () => {
+    permanentlyDeleteDeletedAssignments(
+      Array.from(selectedDeletedAssignments.values())
+    );
+  });
+  toolsElem.appendChild(permanentDeleteBtn);
+  wrapperElem.appendChild(toolsElem);
+
+  const controls = { countElem, allowRefetchBtn, permanentDeleteBtn };
+  updateSelectedRefetchControls(selectedDeletedAssignments, controls);
+
+  const tableElem = document.createElement('table');
   tableElem.border = '0';
   tableElem.cellPadding = '0';
   tableElem.cellSpacing = '0';
   tableElem.className = 'cs_table2';
-
-  let tbody = document.createElement('tbody');
-  let columns = document.createElement('tr');
+  tableElem.style.width = '100%';
+  const tbody = document.createElement('tbody');
+  const columns = document.createElement('tr');
   columns.innerHTML = `
         <th width="20%">${SUBJECT_TXT}</th>
-        <th width="37%">${ASSIGNMENT_TXT}</th>
-        <th width="10%">${DEADLINE_TXT}</th>
-        <th width="12%">${SHOW_TXT}</th>
+        <th width="38%">${ASSIGNMENT_TXT}</th>
+        <th width="22%">${DEADLINE_TXT}</th>
+        <th width="15%">選択</th>
+    `;
+  tbody.appendChild(columns);
+
+  for (const assignment of deletedAssignments) {
+    const record = document.createElement('tr');
+
+    const subjectColumn = document.createElement('td');
+    subjectColumn.innerText = getDisplaySubject(assignment);
+    record.appendChild(subjectColumn);
+
+    const nameColumn = document.createElement('td');
+    nameColumn.innerText = getDisplayAssignmentName(assignment);
+    record.appendChild(nameColumn);
+
+    const dueColumn = document.createElement('td');
+    dueColumn.align = 'center';
+    dueColumn.innerText = hasValidDue(assignment)
+      ? new Date(assignment.due).toLocaleString('ja-JP')
+      : NO_DEADLINE_TXT;
+    record.appendChild(dueColumn);
+
+    const selectColumn = document.createElement('td');
+    selectColumn.align = 'center';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        selectedDeletedAssignments.set(assignment['id'], assignment);
+      } else {
+        selectedDeletedAssignments.delete(assignment['id']);
+      }
+      updateSelectedRefetchControls(selectedDeletedAssignments, controls);
+    });
+    selectColumn.appendChild(checkbox);
+    record.appendChild(selectColumn);
+
+    tbody.appendChild(record);
+  }
+
+  tableElem.appendChild(tbody);
+  wrapperElem.appendChild(tableElem);
+  return wrapperElem;
+}
+
+function createCompletedManagementSection() {
+  const wrapperElem = document.createElement('div');
+  wrapperElem.style.display = 'none';
+  wrapperElem.style.margin = '0 0 10px';
+  wrapperElem.style.padding = '8px';
+  wrapperElem.style.border = '1px solid #d6e5eb';
+  wrapperElem.style.borderRadius = '4px';
+  wrapperElem.style.backgroundColor = '#f7fbfc';
+  return wrapperElem;
+}
+
+function renderPopup() {
+  document.body.style.boxSizing = 'border-box';
+  document.body.style.fontFamily =
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+  document.body.style.margin = '10px';
+  document.body.style.minWidth = '620px';
+
+  const controlsElem = document.createElement('div');
+  controlsElem.style.display = 'flex';
+  controlsElem.style.alignItems = 'center';
+  controlsElem.style.flexWrap = 'wrap';
+  controlsElem.style.gap = '8px';
+  controlsElem.style.marginBottom = '8px';
+
+  const showAllBtn = document.createElement('button');
+  showAllBtn.innerText = SHOW_ALL_TXT;
+  stylePopupButton(showAllBtn);
+  showAllBtn.addEventListener('click', showAllAssignments);
+  controlsElem.appendChild(showAllBtn);
+
+  const recordPerPageLabel = document.createElement('label');
+  recordPerPageLabel.innerText = RECORD_IN_PAGE_TXT;
+  recordPerPageLabel.style.marginLeft = 'auto';
+  recordPerPageLabel.style.fontWeight = '700';
+  recordPerPageLabel.style.color = '#444';
+  const recordPerPageInput = document.createElement('input');
+  recordPerPageInput.type = 'number';
+  recordPerPageInput.min = 1;
+  recordPerPageInput.max = 100;
+  recordPerPageInput.style.width = '56px';
+  recordPerPageInput.style.minHeight = '28px';
+  chrome.storage.local.get('PREFERENCES', (data) => {
+    const prefs = data['PREFERENCES'] || DEFAULT_PREFERENCES;
+    recordPerPageInput.value = prefs.recordPerPage;
+  });
+  recordPerPageInput.addEventListener('input', () => {
+    const value = parseInt(recordPerPageInput.value, 10);
+    if (1 <= value && value <= 100) {
+      savePreferences({ recordPerPage: value });
+    } else if (recordPerPageInput.value) {
+      showStatus(ERROR_1_TO_100, '#c0392b');
+    }
+  });
+
+  controlsElem.appendChild(recordPerPageLabel);
+  controlsElem.appendChild(recordPerPageInput);
+
+  const completedCountElem = document.createElement('strong');
+  completedCountElem.style.display = 'none';
+  completedCountElem.style.color = '#444';
+  completedCountElem.style.backgroundColor = '#eef5f8';
+  completedCountElem.style.border = '1px solid #d6e5eb';
+  completedCountElem.style.borderRadius = '4px';
+  completedCountElem.style.padding = '5px 8px';
+  controlsElem.insertBefore(completedCountElem, recordPerPageLabel);
+
+  const completedToggleBtn = document.createElement('button');
+  completedToggleBtn.innerText = SHOW_HIDDEN_ASSIGNMENTS_TXT;
+  stylePopupButton(completedToggleBtn);
+  completedToggleBtn.style.display = 'none';
+  controlsElem.insertBefore(completedToggleBtn, recordPerPageLabel);
+
+  const statusElem = document.createElement('p');
+  statusElem.id = 'assignment-manager-popup-status';
+  statusElem.innerText = STATUS_TXT;
+  statusElem.style.color = '#444';
+  statusElem.style.fontWeight = '700';
+  statusElem.style.margin = '0 0 8px';
+
+  const listBlockElem = document.createElement('div');
+  listBlockElem.id = 'list_block';
+  listBlockElem.style =
+    'margin-bottom: 10px; box-sizing: border-box; width: 620px; max-height: 360px; overflow-y: auto';
+
+  const tableElem = document.createElement('table');
+  tableElem.border = '0';
+  tableElem.cellPadding = '0';
+  tableElem.cellSpacing = '0';
+  tableElem.className = 'cs_table2';
+  tableElem.style.width = '100%';
+
+  const tbody = document.createElement('tbody');
+  const columns = document.createElement('tr');
+  columns.innerHTML = `
+        <th width="20%">${SUBJECT_TXT}</th>
+        <th width="38%">${ASSIGNMENT_TXT}</th>
+        <th width="22%">${DEADLINE_TXT}</th>
+        <th width="15%">${SHOW_TXT}</th>
     `;
 
   tbody.appendChild(columns);
 
-  chrome.storage.sync.get(null, (data) => {
-    let assignments = Object.values(data);
-    assignments.sort((a, b) => new Date(a['due']) - new Date(b['due']));
+  const completedManagementSectionElem = createCompletedManagementSection();
+  completedToggleBtn.addEventListener('click', () => {
+    const isHidden = completedManagementSectionElem.style.display === 'none';
+    completedManagementSectionElem.style.display = isHidden ? 'block' : 'none';
+    completedToggleBtn.innerText = isHidden
+      ? HIDE_HIDDEN_ASSIGNMENTS_TXT
+      : SHOW_HIDDEN_ASSIGNMENTS_TXT;
+  });
 
-    for (const assignment of assignments) {
-      let daysLeft = (new Date(assignment['due']) - new Date()) / 86400000;
+  removeExpiredAssignmentsFromStorage(() => {
+    chrome.storage.sync.get(null, (data) => {
+      const storedAssignments = Object.values(data).filter(
+        (assignment) => assignment && assignment['id'] !== 'PREFERENCES'
+      );
+      const assignments = Object.values(data)
+        .filter(
+          (assignment) =>
+            assignment &&
+            assignment['id'] !== 'PREFERENCES' &&
+            !isDeletedAssignment(assignment)
+        )
+        .sort(compareAssignmentsByDue);
+      const completedAssignmentCount = assignments.filter(
+        (assignment) => assignment['isVisible'] === false
+      ).length;
+      const deletedAssignments = storedAssignments.filter(isDeletedAssignment);
 
-      // subject, name, due, show
-      let record = document.createElement('tr');
+      if (completedAssignmentCount > 0 || deletedAssignments.length > 0) {
+        completedCountElem.innerText = `${HIDDEN_ASSIGNMENTS_TXT} ${completedAssignmentCount}件`;
+        completedCountElem.style.display = 'inline-block';
+        completedToggleBtn.style.display = 'inline-block';
+      }
 
-      //subject
-      let subjectColumn = document.createElement('td');
+      if (completedAssignmentCount > 0) {
+        const completedToolsElem = document.createElement('div');
+        completedToolsElem.style.display = 'flex';
+        completedToolsElem.style.alignItems = 'center';
+        completedToolsElem.style.flexWrap = 'wrap';
+        completedToolsElem.style.gap = '8px';
+        completedToolsElem.style.margin = '0 0 8px';
 
-      let subjectElem = document.createElement('p');
-      subjectElem.innerText =
-        getLanguage() == 'English'
-          ? assignment['subject_en']
-          : assignment['subject_ja'];
+        const deleteCompletedBtn = document.createElement('button');
+        deleteCompletedBtn.innerText = DELETE_COMPLETED_TXT;
+        stylePopupButton(deleteCompletedBtn, 'danger');
+        deleteCompletedBtn.addEventListener(
+          'click',
+          deleteCompletedAssignments
+        );
+        completedToolsElem.appendChild(deleteCompletedBtn);
+        completedManagementSectionElem.appendChild(completedToolsElem);
+      }
 
-      subjectColumn.appendChild(subjectElem);
+      if (deletedAssignments.length > 0) {
+        const stoppedFetchToolsElem = document.createElement('div');
+        stoppedFetchToolsElem.style.display = 'flex';
+        stoppedFetchToolsElem.style.alignItems = 'center';
+        stoppedFetchToolsElem.style.flexWrap = 'wrap';
+        stoppedFetchToolsElem.style.gap = '8px';
 
-      // name
-      let nameColumn = document.createElement('td');
+        const stoppedFetchStatusElem = document.createElement('strong');
+        stoppedFetchStatusElem.innerText = `${STOPPED_FETCH_ASSIGNMENTS_TXT} ${deletedAssignments.length}件`;
+        stoppedFetchStatusElem.style.color = '#555';
+        stoppedFetchStatusElem.style.backgroundColor = '#f6f6f6';
+        stoppedFetchStatusElem.style.border = '1px solid #ddd';
+        stoppedFetchStatusElem.style.borderRadius = '4px';
+        stoppedFetchStatusElem.style.padding = '5px 8px';
+        stoppedFetchToolsElem.appendChild(stoppedFetchStatusElem);
 
-      let nameElem = document.createElement('p');
-      nameElem.innerText = assignment.name;
+        const stoppedFetchToggleBtn = document.createElement('button');
+        stoppedFetchToggleBtn.innerText = SHOW_STOPPED_FETCH_ASSIGNMENTS_TXT;
+        stylePopupButton(stoppedFetchToggleBtn);
+        stoppedFetchToolsElem.appendChild(stoppedFetchToggleBtn);
 
-      nameColumn.appendChild(nameElem);
-
-      // due
-      let dueColumn = document.createElement('td');
-      dueColumn.align = 'center';
-      if (assignment.due)
-        dueColumn.innerText = new Date(assignment.due).toLocaleString('ja-JP');
-      else dueColumn.innerText = ' - ';
-
-      // show
-      let showColumn = document.createElement('td');
-      showColumn.align = 'center';
-
-      let showCheckbox = document.createElement('input');
-      showCheckbox.checked = assignment['isVisible'];
-      showCheckbox.type = 'checkbox';
-      showCheckbox.addEventListener('change', () => {
-        assignment['isVisible'] = showCheckbox.checked;
-        var keypair = {};
-        keypair[assignment['id']] = assignment;
-        chrome.storage.sync.set(keypair);
-      });
-      showColumn.appendChild(showCheckbox);
-
-      let removeButton = document.createElement('button');
-      removeButton.innerText = '🗑';
-      removeButton.addEventListener('click', () => {
-        chrome.storage.sync.remove(assignment['id'], () => {
-          removeButton.parentElement.innerHTML = `<p>'Removed'</p>`;
+        const stoppedFetchSectionElem =
+          createStoppedFetchSection(deletedAssignments);
+        stoppedFetchToggleBtn.addEventListener('click', () => {
+          const isHidden = stoppedFetchSectionElem.style.display === 'none';
+          stoppedFetchSectionElem.style.display = isHidden ? 'block' : 'none';
+          stoppedFetchToggleBtn.innerText = isHidden
+            ? HIDE_STOPPED_FETCH_ASSIGNMENTS_TXT
+            : SHOW_STOPPED_FETCH_ASSIGNMENTS_TXT;
         });
-      });
-      showColumn.appendChild(removeButton);
+        completedManagementSectionElem.appendChild(stoppedFetchToolsElem);
+        completedManagementSectionElem.appendChild(stoppedFetchSectionElem);
+      }
 
-      record.appendChild(subjectColumn);
-      record.appendChild(nameColumn);
-      record.appendChild(dueColumn);
-      record.appendChild(showColumn);
+      if (assignments.length === 0) {
+        const emptyRow = document.createElement('tr');
+        const emptyColumn = document.createElement('td');
+        emptyColumn.colSpan = 4;
+        emptyColumn.innerText = EMPTY_TXT;
+        emptyColumn.style.textAlign = 'center';
+        emptyColumn.style.padding = '12px';
+        emptyRow.appendChild(emptyColumn);
+        tbody.appendChild(emptyRow);
+      }
 
-      tbody.append(record);
-    }
+      for (const assignment of assignments) {
+        const record = document.createElement('tr');
+        if (!isVisibleAssignment(assignment)) {
+          record.style.opacity = '0.65';
+        }
+
+        const subjectColumn = document.createElement('td');
+        const subjectElem = document.createElement('p');
+        subjectElem.innerText = getDisplaySubject(assignment);
+        subjectColumn.appendChild(subjectElem);
+
+        const nameColumn = document.createElement('td');
+        const nameElem = document.createElement('p');
+        nameElem.innerText = getDisplayAssignmentName(assignment);
+        nameColumn.appendChild(nameElem);
+
+        const dueColumn = document.createElement('td');
+        dueColumn.align = 'center';
+        if (hasValidDue(assignment)) {
+          dueColumn.innerText = new Date(assignment.due).toLocaleString(
+            'ja-JP'
+          );
+          if (isOverdue(assignment)) {
+            dueColumn.style.color = '#666';
+            dueColumn.style.fontWeight = '700';
+          }
+        } else {
+          dueColumn.innerText = NO_DEADLINE_TXT;
+          dueColumn.style.color = '#666';
+          dueColumn.style.fontWeight = '700';
+        }
+
+        const showColumn = document.createElement('td');
+        showColumn.align = 'center';
+
+        const showCheckbox = document.createElement('input');
+        showCheckbox.checked = isVisibleAssignment(assignment);
+        showCheckbox.type = 'checkbox';
+        showCheckbox.addEventListener('change', () => {
+          setAssignmentVisibility(
+            assignment,
+            showCheckbox.checked,
+            (result) => {
+              if (result && (result.skippedDeleted || result.skippedMissing)) {
+                showCheckbox.checked = !showCheckbox.checked;
+                const message = result.skippedDeleted
+                  ? '完了リストから消した課題は、この操作では一覧に戻せません。再取得できるようにしてから講義ページを開いてください。'
+                  : '選択した課題はすでに削除されています。画面を更新してください。';
+                showStatus(message, '#c0392b');
+                return;
+              }
+              if (result && result.error) {
+                showCheckbox.checked = !showCheckbox.checked;
+                showStatus(
+                  '変更できませんでした。時間をおいてもう一度試してください。',
+                  '#c0392b'
+                );
+                return;
+              }
+              refreshPopup();
+            }
+          );
+        });
+        showColumn.appendChild(showCheckbox);
+
+        record.appendChild(subjectColumn);
+        record.appendChild(nameColumn);
+        record.appendChild(dueColumn);
+        record.appendChild(showColumn);
+
+        tbody.append(record);
+      }
+    });
   });
 
   tableElem.appendChild(tbody);
   listBlockElem.appendChild(tableElem);
-  listBlockElem.style =
-    'margin-bottom: 10px; box-sizing: border-box; width: 600px; height: 300px; overflow-y: auto';
 
-  document.body.appendChild(bannerElem);
+  document.body.appendChild(controlsElem);
+  document.body.appendChild(statusElem);
+  document.body.appendChild(completedManagementSectionElem);
   document.body.appendChild(listBlockElem);
 }

--- a/src/show_homework_storage.js
+++ b/src/show_homework_storage.js
@@ -4,29 +4,34 @@
 import { Grid, h } from 'gridjs';
 import { jaJP } from 'gridjs/l10n';
 
-var LANGUAGE = getLanguage();
-if (LANGUAGE == '日本語') {
-  var ASSIGNMENTS_TXT = '課題';
-  var LECTURE_TXT = '講義名';
-  var ASSIGNMENT_TXT = '課題名';
-  var DEADLINE_TXT = '提出期限';
-  var ACTION_TXT = '操作';
-  var REMOVE_TXT = '削除';
-  var WELLDONE_TXT = 'おめでとう！';
-  var GRIDJS_LANGUAGE = jaJP;
-  GRIDJS_LANGUAGE['search'] = '検索 (講義名, 課題名, 期限)';
-  GRIDJS_LANGUAGE['pagination']['results'] +=
-    ' ' + 'Shift押しながら項目選択で複数条件ソート';
-} else {
-  var ASSIGNMENTS_TXT = 'Assignments';
-  var LECTURE_TXT = 'Lecture';
-  var ASSIGNMENT_TXT = 'Assignment';
-  var DEADLINE_TXT = 'DEADLINE';
-  var ACTION_TXT = 'Action';
-  var REMOVE_TXT = 'Remove';
-  var WELLDONE_TXT = 'Well done!';
-  var GRIDJS_LANGUAGE = {};
-}
+var LECTURE_TXT = '講義名';
+var ASSIGNMENT_TXT = '課題名';
+var DEADLINE_TXT = '提出期限';
+var ACTION_TXT = '選択';
+var NO_DEADLINE_TXT = '期限なし';
+var EMPTY_ASSIGNMENTS_TXT = '31日以内の未完了課題はありません。';
+var RESTORE_HINT_TXT =
+  '完了した課題は、この画面の「完了した課題」から戻せます。';
+var AUTO_DELETE_COMPLETED_NOTICE_TXT =
+  '完了した課題は提出期限を過ぎると自動で削除されます。';
+var COMPLETE_SELECTED_ASSIGNMENTS_TXT = '選択した課題を完了';
+var NO_SELECTED_ASSIGNMENTS_TXT = '0件選択中';
+var HIDDEN_ASSIGNMENTS_TXT = '完了した課題';
+var SHOW_HIDDEN_ASSIGNMENTS_TXT = '完了した課題を表示';
+var HIDE_HIDDEN_ASSIGNMENTS_TXT = '完了した課題を閉じる';
+var RESTORE_SELECTED_ASSIGNMENTS_TXT = '選択した課題を一覧に戻す';
+var DELETE_COMPLETED_ASSIGNMENTS_TXT = '完了リストを空にする';
+var STOPPED_FETCH_ASSIGNMENTS_TXT = '取得を止めている記録';
+var SHOW_STOPPED_FETCH_ASSIGNMENTS_TXT = '取得を止めている記録を表示';
+var HIDE_STOPPED_FETCH_ASSIGNMENTS_TXT = '取得を止めている記録を閉じる';
+var ALLOW_REFETCH_DELETED_ASSIGNMENTS_TXT =
+  '選択した課題を再取得できるようにする';
+var PERMANENTLY_DELETE_STOPPED_FETCH_TXT = '選択した記録を完全に削除';
+var ASSIGNMENT_NAME_PLACEHOLDER = '__ASSIGNMENT_NAME__';
+var GRIDJS_LANGUAGE = jaJP;
+GRIDJS_LANGUAGE['search'] = '検索 (講義名, 課題名, 期限)';
+GRIDJS_LANGUAGE['pagination']['results'] +=
+  ' ' + 'Shift押しながら項目選択で複数条件ソート';
 
 /* main */
 (() => {
@@ -40,10 +45,22 @@ function getLanguage() {
   return LOGOUT_TEXT.includes('Logout') ? 'English' : '日本語';
 }
 
-function getAssignmentsFromStorage() {
-  let assignments = [];
+function getDisplaySubject(assignment, subjectNamesById = new Map()) {
+  return (
+    subjectNamesById.get(assignment['subject_id']) ||
+    assignment['subject_ja'] ||
+    assignment['subject_en'] ||
+    ''
+  );
+}
 
-  return assignments;
+function getDisplayAssignmentName(assignment, subjectNamesById = new Map()) {
+  return (
+    assignment['name'] ||
+    getDisplaySubject(assignment, subjectNamesById) ||
+    assignment['id'] ||
+    ''
+  );
 }
 
 function getIconURLFromID(hw_name) {
@@ -62,181 +79,1256 @@ function getIconURLFromID(hw_name) {
   }
 }
 
+function getDueSortTime(assignment) {
+  if (!assignment || !assignment['due']) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const dueTime = new Date(assignment['due']).getTime();
+  return Number.isFinite(dueTime) ? dueTime : Number.POSITIVE_INFINITY;
+}
+
+function compareAssignmentsByDue(a, b) {
+  return getDueSortTime(a) - getDueSortTime(b);
+}
+
+function hasValidDue(assignment) {
+  return Number.isFinite(getDueSortTime(assignment));
+}
+
+function isOverdue(assignment) {
+  return hasValidDue(assignment) && getDueSortTime(assignment) <= Date.now();
+}
+
+function isVisibleAssignment(assignment) {
+  return assignment && assignment['isVisible'] !== false;
+}
+
+function isDeletedAssignment(assignment) {
+  return assignment && assignment['isDeleted'] === true;
+}
+
+function createDeletedAssignmentTombstone(assignment) {
+  return {
+    id: assignment['id'],
+    subject_id: assignment['subject_id'],
+    subject_ja: assignment['subject_ja'],
+    subject_en: assignment['subject_en'],
+    name: assignment['name'],
+    due: assignment['due'],
+    isVisible: false,
+    isDeleted: true,
+    deletedAt: new Date().toJSON(),
+    deletedReason: 'completedCleanup',
+  };
+}
+
+function createLmsSubjectMap(lectureURIElems) {
+  const subjectNamesById = new Map();
+  for (const lectureElem of lectureURIElems) {
+    const text = (lectureElem.parentElement?.textContent || '').trim();
+    const match = text.match(/(.+?)\s*\[([^\]]+)\]/);
+    if (!match) {
+      continue;
+    }
+    const linkText = (lectureElem.textContent || '').trim();
+    let subjectName = match[1].trim();
+    if (linkText && subjectName.startsWith(linkText)) {
+      const subjectNameWithoutLinkText = subjectName
+        .slice(linkText.length)
+        .trim();
+      if (subjectNameWithoutLinkText) {
+        subjectName = subjectNameWithoutLinkText;
+      }
+    }
+    subjectNamesById.set(match[2].trim(), subjectName);
+  }
+  return subjectNamesById;
+}
+
+function backfillDeletedAssignmentMetadataFromLms(data, subjectNamesById) {
+  const updates = {};
+  for (const assignment of Object.values(data)) {
+    if (!isDeletedAssignment(assignment) || !assignment['subject_id']) {
+      continue;
+    }
+    const lmsSubjectName = subjectNamesById.get(assignment['subject_id']);
+    if (!lmsSubjectName) {
+      continue;
+    }
+    if (assignment['name'] && assignment['subject_ja']) {
+      continue;
+    }
+    updates[assignment['id']] = {
+      ...assignment,
+      name: assignment['name'] || lmsSubjectName,
+      subject_ja: assignment['subject_ja'] || lmsSubjectName,
+    };
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return;
+  }
+
+  chrome.storage.sync.set(updates, () => {
+    if (chrome.runtime.lastError) {
+      showStatusMessage(
+        document.body,
+        '取得を止めている記録の科目名を保存できませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+    }
+  });
+}
+
+function showStatusMessage(container, message, color = '#2285b1') {
+  let statusElem = container.querySelector('.assignment-manager-status');
+  if (!statusElem) {
+    statusElem = document.createElement('p');
+    statusElem.className = 'assignment-manager-status';
+    statusElem.style.fontWeight = '700';
+    statusElem.style.margin = '8px 0';
+    container.prepend(statusElem);
+  }
+  statusElem.style.color = color;
+  statusElem.innerText = message;
+}
+
+function createNoDeadlineElem() {
+  const noDeadlineElem = document.createElement('span');
+  noDeadlineElem.innerText = NO_DEADLINE_TXT;
+  noDeadlineElem.style.color = '#666';
+  noDeadlineElem.style.fontWeight = '700';
+  return noDeadlineElem;
+}
+
+function formatDueText(assignment) {
+  if (!hasValidDue(assignment)) {
+    return NO_DEADLINE_TXT;
+  }
+  return new Date(assignment['due']).toLocaleString('ja-JP');
+}
+
+function showEmptyState(container) {
+  const gridContainer = container.querySelector('.gridjs-container');
+  if (gridContainer) {
+    gridContainer.style.display = 'none';
+  }
+
+  let emptyElem = container.querySelector('.assignment-manager-empty');
+  if (!emptyElem) {
+    emptyElem = document.createElement('p');
+    emptyElem.className = 'assignment-manager-empty';
+    emptyElem.style.margin = '12px 0';
+    emptyElem.style.color = '#444';
+    emptyElem.style.fontWeight = '700';
+    container.appendChild(emptyElem);
+  }
+  emptyElem.innerText = EMPTY_ASSIGNMENTS_TXT;
+}
+
+function refreshAssignmentTable(container, delay = 0) {
+  setTimeout(() => {
+    if (container && container.parentElement) {
+      container.remove();
+      injectAssignmentTable();
+      return;
+    }
+    window.location.reload();
+  }, delay);
+}
+
+function createSecondaryButton(text, variant = 'default') {
+  const buttonElem = document.createElement('button');
+  buttonElem.type = 'button';
+  buttonElem.innerText = text;
+  buttonElem.style.minHeight = '30px';
+  buttonElem.style.padding = '4px 10px';
+  buttonElem.style.border = '1px solid #b8c7d0';
+  buttonElem.style.borderRadius = '4px';
+  buttonElem.style.backgroundColor = '#fff';
+  buttonElem.style.color = '#226c86';
+  buttonElem.style.cursor = 'pointer';
+  buttonElem.style.fontWeight = '700';
+  buttonElem.style.lineHeight = '1.3';
+  if (variant === 'danger') {
+    buttonElem.style.backgroundColor = '#fff7f7';
+    buttonElem.style.borderColor = '#d8a5a5';
+    buttonElem.style.color = '#9f2b2b';
+  } else if (variant === 'primary') {
+    buttonElem.style.backgroundColor = '#176f86';
+    buttonElem.style.borderColor = '#176f86';
+    buttonElem.style.color = '#fff';
+  }
+  return buttonElem;
+}
+
+function formatSelectedAssignmentCount(count) {
+  if (count === 0) {
+    return NO_SELECTED_ASSIGNMENTS_TXT;
+  }
+  return `${count}件選択済み`;
+}
+
+function updateSelectedCompletionControls(selectedAssignments, controls) {
+  if (!controls.countElem || !controls.completeBtn) {
+    return;
+  }
+
+  const selectedCount = selectedAssignments.size;
+  controls.countElem.innerText = formatSelectedAssignmentCount(selectedCount);
+  controls.completeBtn.disabled = selectedCount === 0;
+  controls.completeBtn.style.cursor =
+    selectedCount === 0 ? 'not-allowed' : 'pointer';
+  controls.completeBtn.style.opacity = selectedCount === 0 ? '0.55' : '1';
+}
+
+function updateSelectedRestoreControls(selectedAssignments, controls) {
+  if (!controls.countElem || !controls.restoreBtn) {
+    return;
+  }
+
+  const selectedCount = selectedAssignments.size;
+  controls.countElem.innerText = formatSelectedAssignmentCount(selectedCount);
+  controls.restoreBtn.disabled = selectedCount === 0;
+  controls.restoreBtn.style.cursor =
+    selectedCount === 0 ? 'not-allowed' : 'pointer';
+  controls.restoreBtn.style.opacity = selectedCount === 0 ? '0.55' : '1';
+  if (!controls.permanentDeleteBtn) {
+    return;
+  }
+
+  controls.permanentDeleteBtn.disabled = selectedCount === 0;
+  controls.permanentDeleteBtn.style.cursor =
+    selectedCount === 0 ? 'not-allowed' : 'pointer';
+  controls.permanentDeleteBtn.style.opacity =
+    selectedCount === 0 ? '0.55' : '1';
+}
+
+function updateSelectedRefetchControls(selectedAssignments, controls) {
+  updateSelectedRestoreControls(selectedAssignments, controls);
+}
+
+function createTableControls(
+  container,
+  hiddenAssignments,
+  deletedAssignments,
+  activeAssignmentCount,
+  selectedAssignments,
+  selectionControls,
+  subjectNamesById = new Map()
+) {
+  const wrapperElem = document.createElement('div');
+  wrapperElem.style.margin = '8px 0 10px';
+
+  const controlsElem = document.createElement('div');
+  controlsElem.style.display = 'flex';
+  controlsElem.style.alignItems = 'center';
+  controlsElem.style.flexWrap = 'wrap';
+  controlsElem.style.gap = '8px';
+  controlsElem.style.margin = '0 0 4px';
+
+  if (activeAssignmentCount > 0) {
+    const selectionToolsElem = document.createElement('div');
+    selectionToolsElem.style.display = 'flex';
+    selectionToolsElem.style.alignItems = 'center';
+    selectionToolsElem.style.flexWrap = 'wrap';
+    selectionToolsElem.style.gap = '8px';
+
+    const selectedCountElem = document.createElement('strong');
+    selectedCountElem.style.color = '#1f4f5e';
+    selectedCountElem.style.backgroundColor = '#eaf3f6';
+    selectedCountElem.style.border = '1px solid #cfe0e6';
+    selectedCountElem.style.borderRadius = '4px';
+    selectedCountElem.style.padding = '5px 8px';
+    selectedCountElem.style.lineHeight = '1.3';
+    selectionToolsElem.appendChild(selectedCountElem);
+
+    const completeSelectedBtn = createSecondaryButton(
+      COMPLETE_SELECTED_ASSIGNMENTS_TXT,
+      'primary'
+    );
+    completeSelectedBtn.addEventListener('click', () => {
+      completeSelectedAssignments(
+        container,
+        Array.from(selectedAssignments.values()),
+        selectedAssignments,
+        selectionControls
+      );
+    });
+    selectionToolsElem.appendChild(completeSelectedBtn);
+
+    selectionControls.countElem = selectedCountElem;
+    selectionControls.completeBtn = completeSelectedBtn;
+    updateSelectedCompletionControls(selectedAssignments, selectionControls);
+    controlsElem.appendChild(selectionToolsElem);
+  }
+
+  let hiddenSectionElem;
+  if (hiddenAssignments.length > 0 || deletedAssignments.length > 0) {
+    const hiddenToolsElem = document.createElement('div');
+    hiddenToolsElem.style.display = 'flex';
+    hiddenToolsElem.style.alignItems = 'center';
+    hiddenToolsElem.style.flexWrap = 'wrap';
+    hiddenToolsElem.style.gap = '8px';
+
+    const hiddenCountElem = document.createElement('strong');
+    hiddenCountElem.innerText = `${HIDDEN_ASSIGNMENTS_TXT} ${hiddenAssignments.length}件`;
+    hiddenCountElem.style.color = '#444';
+    hiddenCountElem.style.backgroundColor = '#eef5f8';
+    hiddenCountElem.style.border = '1px solid #d6e5eb';
+    hiddenCountElem.style.borderRadius = '4px';
+    hiddenCountElem.style.padding = '5px 8px';
+    hiddenCountElem.style.lineHeight = '1.3';
+    hiddenToolsElem.appendChild(hiddenCountElem);
+
+    const autoDeleteNoticeElem = document.createElement('span');
+    autoDeleteNoticeElem.innerText = AUTO_DELETE_COMPLETED_NOTICE_TXT;
+    autoDeleteNoticeElem.style.color = '#555';
+    autoDeleteNoticeElem.style.fontWeight = '700';
+    hiddenToolsElem.appendChild(autoDeleteNoticeElem);
+
+    const showHiddenBtn = createSecondaryButton(SHOW_HIDDEN_ASSIGNMENTS_TXT);
+    hiddenSectionElem = createHiddenAssignmentsSection(
+      container,
+      hiddenAssignments,
+      deletedAssignments,
+      subjectNamesById
+    );
+    showHiddenBtn.addEventListener('click', () => {
+      const isHidden = hiddenSectionElem.style.display === 'none';
+      hiddenSectionElem.style.display = isHidden ? 'block' : 'none';
+      showHiddenBtn.innerText = isHidden
+        ? HIDE_HIDDEN_ASSIGNMENTS_TXT
+        : SHOW_HIDDEN_ASSIGNMENTS_TXT;
+    });
+    hiddenToolsElem.appendChild(showHiddenBtn);
+
+    controlsElem.appendChild(hiddenToolsElem);
+  }
+
+  wrapperElem.appendChild(controlsElem);
+  if (hiddenAssignments.length > 0) {
+    const hintElem = document.createElement('p');
+    hintElem.innerText = RESTORE_HINT_TXT;
+    hintElem.style.margin = '2px 0 0';
+    hintElem.style.color = '#555';
+    hintElem.style.fontSize = '12px';
+    hintElem.style.fontWeight = '700';
+    wrapperElem.appendChild(hintElem);
+  }
+  if (hiddenSectionElem) {
+    wrapperElem.appendChild(hiddenSectionElem);
+  }
+
+  return wrapperElem;
+}
+
+function completeSelectedAssignments(
+  container,
+  assignments,
+  selectedAssignments,
+  selectionControls
+) {
+  const visibleAssignments = assignments.filter(
+    (assignment) => assignment && isVisibleAssignment(assignment)
+  );
+
+  if (visibleAssignments.length === 0) {
+    showStatusMessage(container, '完了にする課題が選択されていません。');
+    return;
+  }
+
+  if (selectionControls.completeBtn) {
+    selectionControls.completeBtn.disabled = true;
+  }
+
+  const assignmentIds = visibleAssignments.map(
+    (assignment) => assignment['id']
+  );
+
+  chrome.storage.sync.get(assignmentIds, (currentData) => {
+    if (chrome.runtime.lastError) {
+      showStatusMessage(
+        container,
+        '選択した課題を完了にできませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      updateSelectedCompletionControls(selectedAssignments, selectionControls);
+      return;
+    }
+
+    const updates = {};
+    let skippedCount = 0;
+    for (const assignment of visibleAssignments) {
+      const currentAssignment = currentData[assignment['id']];
+      if (
+        !currentAssignment ||
+        isDeletedAssignment(currentAssignment) ||
+        !isVisibleAssignment(currentAssignment)
+      ) {
+        skippedCount++;
+        continue;
+      }
+      updates[assignment['id']] = {
+        ...currentAssignment,
+        isVisible: false,
+        hiddenAt: new Date().toJSON(),
+        hiddenReason: 'done',
+      };
+    }
+
+    const completedCount = Object.keys(updates).length;
+    if (completedCount === 0) {
+      showStatusMessage(
+        container,
+        '選択した課題はすでに移動または削除されています。画面を更新してください。'
+      );
+      selectedAssignments.clear();
+      updateSelectedCompletionControls(selectedAssignments, selectionControls);
+      return;
+    }
+
+    chrome.storage.sync.set(updates, () => {
+      if (chrome.runtime.lastError) {
+        showStatusMessage(
+          container,
+          '選択した課題を完了にできませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        updateSelectedCompletionControls(
+          selectedAssignments,
+          selectionControls
+        );
+        return;
+      }
+
+      selectedAssignments.clear();
+      updateSelectedCompletionControls(selectedAssignments, selectionControls);
+      const skippedMessage =
+        skippedCount > 0
+          ? ` ${skippedCount}件はすでに移動または削除されていたため変更しませんでした。`
+          : '';
+      showStatusMessage(
+        container,
+        `${completedCount}件を完了にしました。「完了した課題を表示」から一覧に戻せます。提出期限を過ぎると自動で削除されます。${skippedMessage}`
+      );
+      refreshAssignmentTable(container, 1200);
+    });
+  });
+}
+
+function removeExpiredAssignmentsFromStorage(callback = () => {}) {
+  chrome.storage.sync.get(null, (data) => {
+    if (chrome.runtime.lastError) {
+      showStatusMessage(
+        document.body,
+        '期限切れ課題を確認できませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      callback();
+      return;
+    }
+
+    const expiredAssignmentIds = [];
+    for (const assignment of Object.values(data)) {
+      if (
+        assignment &&
+        assignment['id'] &&
+        assignment['id'] !== 'PREFERENCES' &&
+        isOverdue(assignment)
+      ) {
+        expiredAssignmentIds.push(assignment['id']);
+      }
+    }
+
+    if (expiredAssignmentIds.length === 0) {
+      callback();
+      return;
+    }
+
+    chrome.storage.sync.remove(expiredAssignmentIds, () => {
+      if (chrome.runtime.lastError) {
+        showStatusMessage(
+          document.body,
+          '期限切れ課題を自動削除できませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+      }
+      callback();
+    });
+  });
+}
+
+function restoreAssignments(container, assignments) {
+  const assignmentIds = assignments
+    .filter((assignment) => assignment && assignment['id'])
+    .map((assignment) => assignment['id']);
+  if (assignmentIds.length === 0) {
+    showStatusMessage(container, '一覧に戻す課題が選択されていません。');
+    return;
+  }
+
+  chrome.storage.sync.get(assignmentIds, (currentData) => {
+    if (chrome.runtime.lastError) {
+      showStatusMessage(
+        container,
+        '課題を一覧に戻せませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      return;
+    }
+
+    const updates = {};
+    let skippedDeletedCount = 0;
+    let skippedMissingCount = 0;
+    for (const assignment of assignments) {
+      if (!assignment || !assignment['id']) {
+        continue;
+      }
+      const currentAssignment = currentData[assignment['id']];
+      if (!currentAssignment) {
+        skippedMissingCount++;
+        continue;
+      }
+      if (isDeletedAssignment(currentAssignment)) {
+        skippedDeletedCount++;
+        continue;
+      }
+      const restoredAssignment = {
+        ...currentAssignment,
+        isVisible: true,
+      };
+      delete restoredAssignment['hiddenAt'];
+      delete restoredAssignment['hiddenReason'];
+      delete restoredAssignment['isDeleted'];
+      delete restoredAssignment['deletedAt'];
+      delete restoredAssignment['deletedReason'];
+      updates[assignment['id']] = restoredAssignment;
+    }
+
+    const restoreCount = Object.keys(updates).length;
+    if (restoreCount === 0) {
+      const message =
+        skippedDeletedCount > 0
+          ? '完了リストから消した課題は、この操作では一覧に戻せません。再取得できるようにしてから講義ページを開いてください。'
+          : skippedMissingCount > 0
+          ? '選択した課題はすでに削除されています。画面を更新してください。'
+          : '一覧に戻す課題が選択されていません。';
+      showStatusMessage(container, message);
+      return;
+    }
+
+    chrome.storage.sync.set(updates, () => {
+      if (chrome.runtime.lastError) {
+        showStatusMessage(
+          container,
+          '課題を一覧に戻せませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+
+      const skippedMessage =
+        skippedDeletedCount > 0
+          ? ` ${skippedDeletedCount}件は完了リストから消されていたため戻しませんでした。`
+          : skippedMissingCount > 0
+          ? ` ${skippedMissingCount}件はすでに削除されていたため戻しませんでした。`
+          : '';
+      showStatusMessage(
+        container,
+        `${restoreCount}件を一覧に戻しました。${skippedMessage}`
+      );
+      refreshAssignmentTable(container, 1200);
+    });
+  });
+}
+
+function deleteHiddenAssignments(container) {
+  chrome.storage.sync.get(null, (data) => {
+    const hiddenAssignments = Object.values(data).filter(
+      (assignment) =>
+        assignment &&
+        assignment['id'] !== 'PREFERENCES' &&
+        assignment['isVisible'] === false &&
+        !isDeletedAssignment(assignment)
+    );
+    const hiddenAssignmentIds = hiddenAssignments.map(
+      (assignment) => assignment['id']
+    );
+
+    if (hiddenAssignmentIds.length === 0) {
+      showStatusMessage(container, '完了リストはすでに空です。');
+      return;
+    }
+
+    const shouldDelete = window.confirm(
+      `完了リスト内の${hiddenAssignmentIds.length}件をこの画面から消します。消した課題はこの画面では戻せませんが、同じ課題が自動で再追加されないように記録だけ残します。必要な課題は先に「一覧に戻す」で戻してください。`
+    );
+    if (!shouldDelete) {
+      return;
+    }
+
+    const updates = {};
+    for (const assignment of hiddenAssignments) {
+      updates[assignment['id']] = createDeletedAssignmentTombstone(assignment);
+    }
+
+    chrome.storage.sync.set(updates, () => {
+      if (chrome.runtime.lastError) {
+        showStatusMessage(
+          container,
+          '完了リストを空にできませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+
+      showStatusMessage(
+        container,
+        `${hiddenAssignmentIds.length}件を完了リストから消しました。`
+      );
+      refreshAssignmentTable(container, 1200);
+    });
+  });
+}
+
+function allowDeletedAssignmentsRefetch(container, assignments) {
+  const assignmentIds = assignments
+    .filter((assignment) => assignment && assignment['id'])
+    .map((assignment) => assignment['id']);
+  if (assignmentIds.length === 0) {
+    showStatusMessage(
+      container,
+      '再取得できるようにする課題が選択されていません。'
+    );
+    return;
+  }
+
+  chrome.storage.sync.get(assignmentIds, (data) => {
+    if (chrome.runtime.lastError) {
+      showStatusMessage(
+        container,
+        '課題を再取得できる状態に戻せませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      return;
+    }
+
+    const deletedAssignmentIds = Object.values(data)
+      .filter(isDeletedAssignment)
+      .map((assignment) => assignment['id']);
+    if (deletedAssignmentIds.length === 0) {
+      showStatusMessage(
+        container,
+        '再取得できるようにする課題が選択されていません。'
+      );
+      return;
+    }
+
+    const shouldAllowRefetch = window.confirm(
+      `選択した${deletedAssignmentIds.length}件を、講義ページを開いたときに再取得できる状態に戻します。LMS上で未提出・未回答として残っている課題だけが取得されます。`
+    );
+    if (!shouldAllowRefetch) {
+      return;
+    }
+
+    chrome.storage.sync.remove(deletedAssignmentIds, () => {
+      if (chrome.runtime.lastError) {
+        showStatusMessage(
+          container,
+          '課題を再取得できる状態に戻せませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+
+      showStatusMessage(
+        container,
+        `${deletedAssignmentIds.length}件を再取得できる状態に戻しました。該当する講義ページを開くと取得されます。`
+      );
+      refreshAssignmentTable(container, 1200);
+    });
+  });
+}
+
+function permanentlyDeleteDeletedAssignments(container, assignments) {
+  const assignmentIds = assignments
+    .filter((assignment) => assignment && assignment['id'])
+    .map((assignment) => assignment['id']);
+  if (assignmentIds.length === 0) {
+    showStatusMessage(container, '完全に削除する記録が選択されていません。');
+    return;
+  }
+
+  chrome.storage.sync.get(assignmentIds, (data) => {
+    if (chrome.runtime.lastError) {
+      showStatusMessage(
+        container,
+        '取得を止めている記録を完全に削除できませんでした。時間をおいてもう一度試してください。',
+        '#c0392b'
+      );
+      return;
+    }
+
+    const deletedAssignmentIds = Object.values(data)
+      .filter(isDeletedAssignment)
+      .map((assignment) => assignment['id']);
+    if (deletedAssignmentIds.length === 0) {
+      showStatusMessage(container, '完全に削除する記録が選択されていません。');
+      return;
+    }
+
+    const shouldDeletePermanently = window.confirm(
+      `選択した${deletedAssignmentIds.length}件の取得を止めている記録を完全に削除します。LMS上に同じ未提出・未回答課題が残っている場合、講義ページを開くと再取得されることがあります。`
+    );
+    if (!shouldDeletePermanently) {
+      return;
+    }
+
+    chrome.storage.sync.remove(deletedAssignmentIds, () => {
+      if (chrome.runtime.lastError) {
+        showStatusMessage(
+          container,
+          '取得を止めている記録を完全に削除できませんでした。時間をおいてもう一度試してください。',
+          '#c0392b'
+        );
+        return;
+      }
+
+      showStatusMessage(
+        container,
+        `${deletedAssignmentIds.length}件の取得を止めている記録を完全に削除しました。`
+      );
+      refreshAssignmentTable(container, 1200);
+    });
+  });
+}
+
+function createHiddenAssignmentsSection(
+  container,
+  hiddenAssignments,
+  deletedAssignments,
+  subjectNamesById = new Map()
+) {
+  const sectionElem = document.createElement('div');
+  sectionElem.style.display = 'none';
+  sectionElem.style.margin = '8px 0 14px';
+  sectionElem.style.maxHeight = '320px';
+  sectionElem.style.overflowY = 'auto';
+
+  const sectionToolsElem = document.createElement('div');
+  sectionToolsElem.style.display = 'flex';
+  sectionToolsElem.style.alignItems = 'center';
+  sectionToolsElem.style.flexWrap = 'wrap';
+  sectionToolsElem.style.gap = '8px';
+  sectionToolsElem.style.margin = '0 0 8px';
+
+  const selectedHiddenAssignments = new Map();
+  const restoreControls = {
+    countElem: null,
+    restoreBtn: null,
+  };
+
+  const selectedCountElem = document.createElement('strong');
+  selectedCountElem.style.color = '#1f4f5e';
+  selectedCountElem.style.backgroundColor = '#eaf3f6';
+  selectedCountElem.style.border = '1px solid #cfe0e6';
+  selectedCountElem.style.borderRadius = '4px';
+  selectedCountElem.style.padding = '5px 8px';
+  selectedCountElem.style.lineHeight = '1.3';
+  sectionToolsElem.appendChild(selectedCountElem);
+
+  const restoreSelectedBtn = createSecondaryButton(
+    RESTORE_SELECTED_ASSIGNMENTS_TXT,
+    'primary'
+  );
+  restoreSelectedBtn.addEventListener('click', () => {
+    restoreAssignments(
+      container,
+      Array.from(selectedHiddenAssignments.values())
+    );
+  });
+  sectionToolsElem.appendChild(restoreSelectedBtn);
+  restoreControls.countElem = selectedCountElem;
+  restoreControls.restoreBtn = restoreSelectedBtn;
+  updateSelectedRestoreControls(selectedHiddenAssignments, restoreControls);
+
+  const deleteCompletedBtn = createSecondaryButton(
+    DELETE_COMPLETED_ASSIGNMENTS_TXT,
+    'danger'
+  );
+  deleteCompletedBtn.addEventListener('click', () => {
+    deleteHiddenAssignments(container);
+  });
+  sectionToolsElem.appendChild(deleteCompletedBtn);
+
+  if (hiddenAssignments.length > 0) {
+    const tableElem = createAssignmentSelectionTable(
+      hiddenAssignments,
+      selectedHiddenAssignments,
+      restoreControls,
+      `${ASSIGNMENT_NAME_PLACEHOLDER}を一覧に戻す対象として選択`,
+      subjectNamesById
+    );
+    sectionElem.appendChild(sectionToolsElem);
+    sectionElem.appendChild(tableElem);
+  } else {
+    const emptyCompletedElem = document.createElement('p');
+    emptyCompletedElem.innerText = '一覧に戻せる完了課題はありません。';
+    emptyCompletedElem.style.margin = '6px 0 10px';
+    emptyCompletedElem.style.color = '#555';
+    emptyCompletedElem.style.fontWeight = '700';
+    sectionElem.appendChild(emptyCompletedElem);
+  }
+
+  if (deletedAssignments.length > 0) {
+    sectionElem.appendChild(
+      createStoppedFetchSection(container, deletedAssignments, subjectNamesById)
+    );
+  }
+
+  return sectionElem;
+}
+
+function createAssignmentSelectionTable(
+  assignments,
+  selectedAssignments,
+  controls,
+  ariaLabelTemplate,
+  subjectNamesById = new Map()
+) {
+  const tableElem = document.createElement('table');
+  tableElem.style.width = '100%';
+  tableElem.style.borderCollapse = 'collapse';
+  tableElem.style.backgroundColor = '#fff';
+  const headerRowElem = document.createElement('tr');
+  for (const headerText of [
+    LECTURE_TXT,
+    ASSIGNMENT_TXT,
+    DEADLINE_TXT,
+    ACTION_TXT,
+  ]) {
+    const headerElem = document.createElement('th');
+    headerElem.innerText = headerText;
+    headerElem.style.textAlign = 'left';
+    headerElem.style.borderBottom = '1px solid #ddd';
+    headerElem.style.padding = '6px';
+    headerRowElem.appendChild(headerElem);
+  }
+  tableElem.appendChild(headerRowElem);
+
+  for (const assignment of assignments) {
+    const rowElem = document.createElement('tr');
+    rowElem.style.color = '#555';
+
+    const subjectElem = document.createElement('td');
+    subjectElem.innerText = getDisplaySubject(assignment, subjectNamesById);
+    subjectElem.style.padding = '6px';
+    rowElem.appendChild(subjectElem);
+
+    const nameElem = document.createElement('td');
+    nameElem.innerText = getDisplayAssignmentName(assignment, subjectNamesById);
+    nameElem.style.padding = '6px';
+    rowElem.appendChild(nameElem);
+
+    const dueElem = document.createElement('td');
+    dueElem.innerText = formatDueText(assignment);
+    dueElem.style.padding = '6px';
+    rowElem.appendChild(dueElem);
+
+    const selectElem = document.createElement('td');
+    selectElem.style.padding = '6px';
+    selectElem.style.textAlign = 'center';
+    const restoreCheckbox = document.createElement('input');
+    restoreCheckbox.type = 'checkbox';
+    restoreCheckbox.setAttribute(
+      'aria-label',
+      ariaLabelTemplate.replace(
+        ASSIGNMENT_NAME_PLACEHOLDER,
+        getDisplayAssignmentName(assignment, subjectNamesById)
+      )
+    );
+    restoreCheckbox.addEventListener('change', () => {
+      if (restoreCheckbox.checked) {
+        selectedAssignments.set(assignment['id'], assignment);
+      } else {
+        selectedAssignments.delete(assignment['id']);
+      }
+      updateSelectedRestoreControls(selectedAssignments, controls);
+    });
+    selectElem.appendChild(restoreCheckbox);
+    rowElem.appendChild(selectElem);
+
+    tableElem.appendChild(rowElem);
+  }
+
+  return tableElem;
+}
+
+function createStoppedFetchSection(
+  container,
+  deletedAssignments,
+  subjectNamesById = new Map()
+) {
+  const wrapperElem = document.createElement('div');
+  wrapperElem.style.margin = '12px 0 0';
+  wrapperElem.style.borderTop = '1px solid #e1e7ea';
+  wrapperElem.style.paddingTop = '10px';
+
+  const summaryToolsElem = document.createElement('div');
+  summaryToolsElem.style.display = 'flex';
+  summaryToolsElem.style.alignItems = 'center';
+  summaryToolsElem.style.flexWrap = 'wrap';
+  summaryToolsElem.style.gap = '8px';
+
+  const countElem = document.createElement('strong');
+  countElem.innerText = `${STOPPED_FETCH_ASSIGNMENTS_TXT} ${deletedAssignments.length}件`;
+  countElem.style.color = '#555';
+  countElem.style.backgroundColor = '#f6f6f6';
+  countElem.style.border = '1px solid #ddd';
+  countElem.style.borderRadius = '4px';
+  countElem.style.padding = '5px 8px';
+  countElem.style.lineHeight = '1.3';
+  summaryToolsElem.appendChild(countElem);
+
+  const showStoppedFetchBtn = createSecondaryButton(
+    SHOW_STOPPED_FETCH_ASSIGNMENTS_TXT
+  );
+  summaryToolsElem.appendChild(showStoppedFetchBtn);
+  wrapperElem.appendChild(summaryToolsElem);
+
+  const detailElem = document.createElement('div');
+  detailElem.style.display = 'none';
+  detailElem.style.margin = '8px 0 0';
+
+  const selectedDeletedAssignments = new Map();
+  const refetchControls = {
+    countElem: null,
+    restoreBtn: null,
+    permanentDeleteBtn: null,
+  };
+
+  const detailToolsElem = document.createElement('div');
+  detailToolsElem.style.display = 'flex';
+  detailToolsElem.style.alignItems = 'center';
+  detailToolsElem.style.flexWrap = 'wrap';
+  detailToolsElem.style.gap = '8px';
+  detailToolsElem.style.margin = '0 0 8px';
+
+  const selectedCountElem = document.createElement('strong');
+  selectedCountElem.style.color = '#1f4f5e';
+  selectedCountElem.style.backgroundColor = '#eaf3f6';
+  selectedCountElem.style.border = '1px solid #cfe0e6';
+  selectedCountElem.style.borderRadius = '4px';
+  selectedCountElem.style.padding = '5px 8px';
+  selectedCountElem.style.lineHeight = '1.3';
+  detailToolsElem.appendChild(selectedCountElem);
+
+  const allowRefetchBtn = createSecondaryButton(
+    ALLOW_REFETCH_DELETED_ASSIGNMENTS_TXT,
+    'primary'
+  );
+  allowRefetchBtn.addEventListener('click', () => {
+    allowDeletedAssignmentsRefetch(
+      container,
+      Array.from(selectedDeletedAssignments.values())
+    );
+  });
+  detailToolsElem.appendChild(allowRefetchBtn);
+  refetchControls.countElem = selectedCountElem;
+  refetchControls.restoreBtn = allowRefetchBtn;
+
+  const permanentDeleteBtn = createSecondaryButton(
+    PERMANENTLY_DELETE_STOPPED_FETCH_TXT,
+    'danger'
+  );
+  permanentDeleteBtn.addEventListener('click', () => {
+    permanentlyDeleteDeletedAssignments(
+      container,
+      Array.from(selectedDeletedAssignments.values())
+    );
+  });
+  detailToolsElem.appendChild(permanentDeleteBtn);
+  refetchControls.permanentDeleteBtn = permanentDeleteBtn;
+  updateSelectedRefetchControls(selectedDeletedAssignments, refetchControls);
+
+  const tableElem = createAssignmentSelectionTable(
+    deletedAssignments,
+    selectedDeletedAssignments,
+    refetchControls,
+    `${ASSIGNMENT_NAME_PLACEHOLDER}を再取得できるようにする対象として選択`,
+    subjectNamesById
+  );
+  detailElem.appendChild(detailToolsElem);
+  detailElem.appendChild(tableElem);
+
+  showStoppedFetchBtn.addEventListener('click', () => {
+    const isHidden = detailElem.style.display === 'none';
+    detailElem.style.display = isHidden ? 'block' : 'none';
+    showStoppedFetchBtn.innerText = isHidden
+      ? HIDE_STOPPED_FETCH_ASSIGNMENTS_TXT
+      : SHOW_STOPPED_FETCH_ASSIGNMENTS_TXT;
+  });
+
+  wrapperElem.appendChild(detailElem);
+  return wrapperElem;
+}
+
+function getCellText(cell) {
+  if (!cell) {
+    return '';
+  }
+  if (typeof cell === 'string') {
+    return cell.replace(/(<([^>]+)>)/gi, '');
+  }
+  if (typeof cell.textContent === 'string') {
+    return cell.textContent;
+  }
+  if (cell.props) {
+    return getCellText(cell.props.content);
+  }
+  return '';
+}
+
 function injectAssignmentTable() {
   const DISPLAY_LIMIT_DAYS = 31;
   const GAS_TASKAPI_URL =
     'https://script.google.com/macros/s/AKfycbxOkCMKIeXHZPxkVHZbQDlU6ezRRljwJdypjI9B4qA2l3oZqfgtxOzDr6jY1PoN9rTa6Q/exec';
-  let inDleftCnt = 0;
 
   const lectureURIElems = Array.from(
     document.querySelectorAll('[onclick^=formSubmit]')
   );
+  const subjectNamesById = createLmsSubjectMap(lectureURIElems);
 
-  let recordPerPage = 6;
-  chrome.storage.local.get('PREFERENCES', (data) => {
-    console.log(data);
-    const prefs = data['PREFERENCES'];
-    if (prefs['id'] === 'PREFERENCES') {
-      recordPerPage = prefs.recordPerPage;
-    }
-  });
+  getRecordPerPage((recordPerPage) => {
+    removeExpiredAssignmentsFromStorage(() => {
+      chrome.storage.sync.get(null, (data) => {
+        backfillDeletedAssignmentMetadataFromLms(data, subjectNamesById);
+        const assignments = Object.values(data);
+        // Cannot sort items outside chrome.storage.sync.get
+        assignments.sort(compareAssignmentsByDue);
 
-  chrome.storage.sync.get(null, (data) => {
-    const assignments = Object.values(data);
-    // Cannot sort items outside chrome.storage.sync.get
-    assignments.sort((a, b) => new Date(a['due']) - new Date(b['due']));
-
-    let asm = [];
-    for (const assignment of assignments) {
-      if (assignment['id'] === 'PREFERENCES') {
-        continue;
-      }
-      //separated evaluation of visibility and date left
-      if (assignment['isVisible']) {
-        var daysLeft;
-        if (assignment['due']) {
-          daysLeft = (new Date(assignment['due']) - new Date()) / 86400000;
-          if (daysLeft >= DISPLAY_LIMIT_DAYS) continue;
-        }
-        inDleftCnt++;
-
-        let subjectElem = document.createElement('p');
-        if (
-          lectureURIElems.filter((x) =>
-            x.parentElement.textContent.includes(assignment['subject_en'])
-          ).length
-        ) {
-          subjectElem = document.createElement('a');
-          subjectElem.href = 'javascript:void(0)';
-          subjectElem.setAttribute(
-            'onclick',
-            lectureURIElems
-              .filter((x) =>
-                x.parentElement.textContent.includes(assignment['subject_en'])
-              )[0]
-              .getAttribute('onclick')
-          );
-        }
-        subjectElem.innerText =
-          getLanguage() == 'English'
-            ? assignment['subject_en']
-            : assignment['subject_ja'];
-
-        let linkElem = document.createElement('a');
-        if (assignment['due']) {
-          linkElem.href = `${GAS_TASKAPI_URL}?language=${getLanguage()}&subject=${
-            getLanguage() === '日本語'
-              ? assignment['subject_ja']
-              : assignment['subject_en']
-          }&name=${assignment['name']}&due=${new Date(
-            new Date(assignment['due']).getTime() -
-              new Date(assignment['due']).getTimezoneOffset() * 60 * 1000
-          ).toJSON()}&id=${assignment['id']}`;
-          linkElem.innerText = new Date(assignment['due']).toLocaleString(
-            'ja-JP'
-          );
-          if (daysLeft < 0) {
-            linkElem.style = 'color: gray';
-          } else if (daysLeft < 1) {
-            linkElem.style = 'color: red';
-          } else if (daysLeft < 2) {
-            linkElem.style = 'color: #F6AA00';
-          } else if (daysLeft < 7) {
-            linkElem.style = 'color: green';
-          } else {
-            linkElem.style = 'color: turqoise';
+        let asm = [];
+        let hiddenAssignments = [];
+        let deletedAssignments = [];
+        const selectedAssignments = new Map();
+        const selectionControls = {
+          countElem: null,
+          completeBtn: null,
+        };
+        let activeAssignmentCount = 0;
+        for (const assignment of assignments) {
+          if (!assignment) {
+            continue;
           }
-        } else {
-          linkElem.href = `${GAS_TASKAPI_URL}?language=${getLanguage()}&subject=${
-            getLanguage() === '日本語'
-              ? assignment['subject_ja']
-              : assignment['subject_en']
-          }&name=${assignment['name']}&due=&id=${assignment['id']}`;
-          linkElem.innerText = '-';
-        }
-        linkElem.target = '_blank';
-        linkElem.rel = 'noopener nonreferrer';
+          if (assignment['id'] === 'PREFERENCES') {
+            continue;
+          }
+          if (isDeletedAssignment(assignment)) {
+            deletedAssignments.push(assignment);
+            continue;
+          }
+          if (assignment['isVisible'] === false) {
+            hiddenAssignments.push(assignment);
+            continue;
+          }
+          //separated evaluation of visibility and date left
+          if (isVisibleAssignment(assignment)) {
+            var daysLeft;
+            if (hasValidDue(assignment)) {
+              daysLeft = (new Date(assignment['due']) - new Date()) / 86400000;
+              if (daysLeft >= DISPLAY_LIMIT_DAYS) continue;
+            }
+            activeAssignmentCount++;
+            let subjectElem = document.createElement('p');
+            if (
+              lectureURIElems.filter((x) =>
+                x.parentElement.textContent.includes(assignment['subject_en'])
+              ).length
+            ) {
+              subjectElem = document.createElement('a');
+              subjectElem.href = 'javascript:void(0)';
+              subjectElem.setAttribute(
+                'onclick',
+                lectureURIElems
+                  .filter((x) =>
+                    x.parentElement.textContent.includes(
+                      assignment['subject_en']
+                    )
+                  )[0]
+                  .getAttribute('onclick')
+              );
+            }
+            subjectElem.innerText = getDisplaySubject(
+              assignment,
+              subjectNamesById
+            );
 
-        let removeBtn = h(
-          'button',
-          {
-            onClick: () => {
-              chrome.storage.sync.remove(assignment['id'], () => {
-                removeBtn.parentElement.innerHTML = `<p>${WELLDONE_TXT}</p>`;
-              });
-              window.location.reload();
+            let linkElem = document.createElement('a');
+            const taskParams = new URLSearchParams({
+              language: getLanguage(),
+              subject:
+                getLanguage() === '日本語'
+                  ? assignment['subject_ja']
+                  : assignment['subject_en'],
+              name: assignment['name'],
+              due: '',
+              id: assignment['id'],
+            });
+            if (hasValidDue(assignment)) {
+              taskParams.set(
+                'due',
+                new Date(
+                  new Date(assignment['due']).getTime() -
+                    new Date(assignment['due']).getTimezoneOffset() * 60 * 1000
+                ).toJSON()
+              );
+              linkElem.href = `${GAS_TASKAPI_URL}?${taskParams.toString()}`;
+              linkElem.innerText = new Date(assignment['due']).toLocaleString(
+                'ja-JP'
+              );
+              if (daysLeft < 0) {
+                linkElem.style = 'color: gray';
+              } else if (daysLeft < 1) {
+                linkElem.style = 'color: red';
+              } else if (daysLeft < 2) {
+                linkElem.style = 'color: #F6AA00';
+              } else if (daysLeft < 7) {
+                linkElem.style = 'color: green';
+              } else {
+                linkElem.style = 'color: turquoise';
+              }
+            } else {
+              linkElem.href = `${GAS_TASKAPI_URL}?${taskParams.toString()}`;
+              linkElem.appendChild(createNoDeadlineElem());
+            }
+            linkElem.target = '_blank';
+            linkElem.rel = 'noopener noreferrer';
+
+            let selectionCheckbox = h('input', {
+              type: 'checkbox',
+              checked: selectedAssignments.has(assignment['id']),
+              'aria-label': `${getDisplayAssignmentName(
+                assignment,
+                subjectNamesById
+              )}を選択`,
+              onChange: (event) => {
+                if (event.currentTarget.checked) {
+                  selectedAssignments.set(assignment['id'], assignment);
+                } else {
+                  selectedAssignments.delete(assignment['id']);
+                }
+                updateSelectedCompletionControls(
+                  selectedAssignments,
+                  selectionControls
+                );
+              },
+              style: {
+                width: '18px',
+                height: '18px',
+                cursor: 'pointer',
+              },
+            });
+            asm.push([
+              subjectElem,
+              getDisplayAssignmentName(assignment, subjectNamesById),
+              linkElem,
+              selectionCheckbox,
+            ]);
+          }
+        }
+
+        let mainElem = document.querySelector('div.contentsColumn');
+        const tableElem = document.createElement('div');
+        tableElem.appendChild(
+          createTableControls(
+            tableElem,
+            hiddenAssignments,
+            deletedAssignments,
+            activeAssignmentCount,
+            selectedAssignments,
+            selectionControls,
+            subjectNamesById
+          )
+        );
+        if (activeAssignmentCount === 0) {
+          showEmptyState(tableElem);
+          mainElem.prepend(tableElem);
+          return;
+        }
+        const gridMountElem = document.createElement('div');
+        tableElem.appendChild(gridMountElem);
+        new Grid({
+          columns: [
+            {
+              name: LECTURE_TXT,
+              width: '25%',
+              sort: {
+                compare: (a, b) => {
+                  const aText = getCellText(a);
+                  const bText = getCellText(b);
+                  if (aText > bText) {
+                    return 1;
+                  } else if (bText > aText) {
+                    return -1;
+                  } else {
+                    return 0;
+                  }
+                },
+              },
             },
-            style: {
+            { name: ASSIGNMENT_TXT, width: '40%' },
+            {
+              name: DEADLINE_TXT,
+              width: '20%',
+              sort: false,
+            },
+            {
+              name: ACTION_TXT,
+              width: '10%',
+              sort: false,
+            },
+          ],
+          style: {
+            table: {
               width: '100%',
-              backgroundColor: 'white',
-              color: '#2285b1',
-              fontWeight: '700',
-              border: '1px solid',
             },
           },
-          REMOVE_TXT
-        );
-        asm.push([subjectElem, assignment['name'], linkElem, removeBtn]);
-      }
-    }
-
-    let mainElem = document.querySelector('div.contentsColumn');
-    const tableElem = document.createElement('div');
-    new Grid({
-      columns: [
-        {
-          name: LECTURE_TXT,
-          width: '25%',
-          sort: {
-            compare: (a, b) => {
-              const aText = a.props.content.replace(/(<([^>]+)>)/gi, '');
-              const bText = b.props.content.replace(/(<([^>]+)>)/gi, '');
-              if (aText > bText) {
-                return 1;
-              } else if (bText > aText) {
-                return -1;
+          search: {
+            selector: (cell, rowIndex, cellIndex) => {
+              if (cellIndex === 0 || cellIndex == 2) {
+                return getCellText(cell);
               } else {
-                return 0;
+                return cell;
               }
             },
           },
-        },
-        { name: ASSIGNMENT_TXT, width: '40%' },
-        {
-          name: DEADLINE_TXT,
-          width: '20%',
-          sort: {
-            compare: (a, b) => {
-              return 1;
-            },
-          },
-        },
-        {
-          name: ACTION_TXT,
-          width: '10%',
-          sort: false,
-        },
-      ],
-      style: {
-        table: {
-          width: '100%',
-        },
-      },
-      search: {
-        selector: (cell, rowIndex, cellIndex) => {
-          if (cellIndex === 0 || cellIndex == 2) {
-            return cell.props.content.replace(/(<([^>]+)>)/gi, '');
-          } else {
-            return cell;
-          }
-        },
-      },
-      data: asm,
-      sort: true,
-      pagination: { limit: recordPerPage, summary: true },
-      language: GRIDJS_LANGUAGE,
-    }).render(tableElem);
-    mainElem.prepend(tableElem);
+          data: asm,
+          sort: true,
+          pagination: { limit: recordPerPage, summary: true },
+          language: GRIDJS_LANGUAGE,
+        }).render(gridMountElem);
+        mainElem.prepend(tableElem);
+      });
+    });
+  });
+}
+
+function getRecordPerPage(callback) {
+  chrome.storage.local.get('PREFERENCES', (data) => {
+    const prefs = data['PREFERENCES'];
+    const recordPerPage = parseInt(prefs && prefs.recordPerPage, 10);
+
+    if (
+      Number.isFinite(recordPerPage) &&
+      1 <= recordPerPage &&
+      recordPerPage <= 100
+    ) {
+      callback(recordPerPage);
+    } else {
+      callback(6);
+    }
   });
 }
 


### PR DESCRIPTION
# 概要

YNU LMSのHOME画面で、課題を拡張機能上の「完了」として扱えるようにしました。

「完了」にした課題は通常の課題一覧から外れます。必要になった場合は、「完了した課題」から元の一覧へ戻せます。完了リストを空にした課題は、提出期限までは再取得しないための記録だけ残し、期限を過ぎたら通常課題・完了済み課題・取得停止記録のどれも `chrome.storage.sync` から削除します。

LMSを巡回する処理、定期fetch、提出やアップロードの操作は追加していません。

## 変更内容

- HOME画面の課題一覧にチェックボックスを追加し、選択した課題をまとめて完了扱いにできるようにしました。
- 完了した課題を「完了した課題」に移し、期限前であれば通常の課題一覧へ戻せるようにしました。
- 「完了リストを空にする」操作を追加しました。完了リストを空にした課題は、提出期限までは `isDeleted: true` の取得停止記録として残します。
- 取得停止記録は「完了した課題」の中で扱い、必要に応じて再取得できる状態へ戻す / 完全にローカル削除する操作を追加しました。
- 期限切れの通常課題、完了済み課題、取得停止記録は、HOME / popup / 講義ページを開いたタイミングで削除するようにしました。
- 講義ページで新しく読み取った課題も、すでに期限切れなら保存しないようにしました。
- `期限なし` 表示、期限値が不正な場合のfallback、講義ページ上で生成するリンク引数のescapeもあわせて調整しました。
- `public/manifest.json` の表示名と説明文を、日本語のYNU LMS利用者向けに更新しました。
  - `name`: `YNU LMS 課題管理`
  - `short_name`: `課題管理`
  - `description`: `YNU LMS の課題を一覧で確認できます`

## 動作の整理

- 既存データとの互換性のため、`isVisible` がない課題は通常一覧に表示します。
- 完了扱いにした課題は `isVisible: false`、`hiddenAt`、`hiddenReason` を持ちます。
- 完了済み課題は、提出期限前であれば通常一覧へ戻せます。
- 完了リストを空にした課題は、提出期限前だけ取得停止記録として残します。
- 提出期限を過ぎた課題は、通常一覧 / 完了リスト / 取得停止記録のどこにあっても自動削除します。
- 自動削除は、HOME / popup / 講義ページを開いた時だけ走ります。バックグラウンド巡回や定期fetchはありません。
- 保存先は `chrome.storage.sync` だけです。外部DBやサーバーへの保存はありません。

レビューでは、特に次の点を見てもらえると助かります。

1. 課題を完了扱いにする操作が、HOME画面上で分かりやすいか。
2. 完了済み課題を戻す操作と、完了リストを空にする操作が混同されにくいか。
3. 完了リストを空にした課題が、期限前に講義ページを開いた時だけ不用意に復活しないか。
4. 期限切れデータの削除が、拡張機能内の `chrome.storage.sync` 整理に留まっているか。
5. `manifest.json` の日本語表示名と説明文が、このPRの範囲として問題ないか。

## スクショ

以下のスクショは、実LMSデータではなくQA用のダミー講義・ダミー課題で撮影しています。

### HOMEで課題を完了扱いにする

HOMEの課題一覧でチェックを入れると、選択した課題をまとめて完了扱いにできます。

![HOMEで課題を選択している画面](https://github.com/user-attachments/assets/cd68a2fa-c3e2-4b3d-9eb2-5cc0a531e6ca)

完了扱いにした課題は通常一覧から外れ、`完了した課題` 側へ移ります。

![完了扱いにした後のHOME画面](https://github.com/user-attachments/assets/bb902425-09ff-4642-afd4-301177a4bdcd)

完了した課題は、期限前であれば通常一覧へ戻せます。

![完了した課題を通常一覧へ戻した後のHOME画面](https://github.com/user-attachments/assets/6ba3755c-856b-4489-846c-eb48a1657f51)

### 完了済み課題の復元

「完了した課題」内で復元対象を選ぶと、通常一覧へ戻す操作が有効になります。

![完了済み課題を選択し、復元操作が有効になっている画面](https://github.com/user-attachments/assets/26ccc7c7-fdfb-4f70-a0b2-5e61db7b73b2)

### 期限切れデータの削除

popupを開いた時点で、期限切れの通常課題・完了済み課題・取得停止記録が削除され、期限前の取得停止記録だけが「取得を止めている記録」に残ることを確認しました。古い `期限切れを完了にする` ボタンも表示されていません。

![popupで期限切れデータが削除され、期限前の取得停止記録だけが残っている画面](https://github.com/user-attachments/assets/0bf019fe-9de5-4951-a3ec-df79323fcca4)

QAでは、mock `chrome.storage` に期限切れ通常課題、期限切れ完了済み課題、期限切れ取得停止記録、期限前取得停止記録を入れた状態でpopupを開きました。結果として期限切れ3件は削除され、期限前1件だけが残りました。Console / Page Errors は出ていません。

## 確認したこと

```bash
pnpm exec prettier --write src/*.js config/*.js public/*.json
pnpm run build
git diff --check origin/main
```

最新のclean branch build確認: `2026-06-25 02:58:17 JST`

- clean PR buildのbrowser DOM QAを実施しました。
- popup-onlyの期限切れ自動削除QAを実施しました。
- QAはlocal mock DOMとmock `chrome.storage` を使っています。
- LMSへのアクセス、network fetch、提出、アップロード、外部状態の変更は行っていません。
- Chrome拡張としてのbuildは `pnpm run build` で確認しています。

## 変更ファイル

- `public/manifest.json`
- `src/fetch_homework_storage.js`
- `src/popup.js`
- `src/show_homework_storage.js`

## 範囲外

- Chrome Web Storeへの反映
- LMSへの提出 / 保存 / アップロード / フォーム操作
- バックグラウンドでのLMS巡回や定期fetch
- 外部DBやサーバーへの保存
