### PR TITLE
manifestの表示名を日本語化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Assignment Manager for YNU LMS",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Manage your homework easily",
   "private": true,
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "YNU LMS 課題管理",
-  "short_name": "課題管理",
+  "name": "YNU LMS かだいくん",
+  "short_name": "かだいくん",
   "description": "YNU LMS の課題を一覧で確認できます",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "author": "Vimmer",
   "icons": {
     "16": "icons/icon_16.png",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Assignment Manager for YNU LMS",
-  "short_name": "ExtOfLMS",
-  "description": "Manage your homework easily",
+  "name": "YNU LMS 課題管理",
+  "short_name": "課題管理",
+  "description": "YNU LMS の課題を一覧で確認できます",
   "version": "2.4.1",
   "author": "Vimmer",
   "icons": {


### PR DESCRIPTION
## 概要

PR #13 の差分を小さく分けるため、Chrome拡張の manifest 表示文言だけを日本語にします。

## 変更内容

- `manifest.json` の `name` を `YNU LMS 課題管理` に変更
- `short_name` を `課題管理` に変更
- `description` を `YNU LMS の課題を一覧で確認できます` に変更

## この PR に含めないこと

- HOME / popup の挙動変更
- 課題の完了・復元対応
- 期限切れ課題の自動削除
- version の更新
- 広いリファクタや一括整形

## 確認したこと

- `pnpm run build`
- `git diff --check origin/main...HEAD`

## レビュー補足

変更ファイルは `public/manifest.json` のみです。
